### PR TITLE
fix: ensure proper client disconnection in RenogyBleClient methods

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -373,6 +373,7 @@ class RenogyBleClient:
         any_command_succeeded = False
         error: Exception | None = None
 
+        client = None
         try:
             client = await establish_connection(
                 BleakClientWithServiceCache,
@@ -473,7 +474,7 @@ class RenogyBleClient:
             logger.error("Error reading data from device %s: %s", device.name, str(exc))
             error = exc
         finally:
-            if client.is_connected:
+            if client is not None:
                 try:
                     await client.disconnect()
                     logger.debug("Disconnected from device %s", device.name)
@@ -500,6 +501,7 @@ class RenogyBleClient:
         """Write a single register value and return success."""
         connection_kwargs = self._connection_kwargs()
 
+        client = None
         try:
             client = await establish_connection(
                 BleakClientWithServiceCache,
@@ -634,7 +636,7 @@ class RenogyBleClient:
                         device.name,
                         str(exc),
                     )
-            if client.is_connected:
+            if client is not None:
                 try:
                     await client.disconnect()
                     logger.debug("Disconnected from device %s", device.name)
@@ -672,6 +674,7 @@ class RenogyBleClient:
         """
         connection_kwargs = self._connection_kwargs()
 
+        client = None
         try:
             client = await establish_connection(
                 BleakClientWithServiceCache,
@@ -777,7 +780,7 @@ class RenogyBleClient:
             logger.error("Error writing to device %s: %s", device.name, str(exc))
             return False
         finally:
-            if client.is_connected:
+            if client is not None:
                 try:
                     await client.disconnect()
                 except Exception as exc:

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -474,7 +474,7 @@ class RenogyBleClient:
             logger.error("Error reading data from device %s: %s", device.name, str(exc))
             error = exc
         finally:
-            if client is not None:
+            if client is not None and client.is_connected:
                 try:
                     await client.disconnect()
                     logger.debug("Disconnected from device %s", device.name)
@@ -636,7 +636,7 @@ class RenogyBleClient:
                         device.name,
                         str(exc),
                     )
-            if client is not None:
+            if client is not None and client.is_connected:
                 try:
                     await client.disconnect()
                     logger.debug("Disconnected from device %s", device.name)
@@ -780,7 +780,7 @@ class RenogyBleClient:
             logger.error("Error writing to device %s: %s", device.name, str(exc))
             return False
         finally:
-            if client is not None:
+            if client is not None and client.is_connected:
                 try:
                     await client.disconnect()
                 except Exception as exc:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -2,8 +2,8 @@
 
 import asyncio
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
 from typing import Callable
+from unittest.mock import MagicMock
 
 from renogy_ble.ble import (
     DEFAULT_DEVICE_ID,

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
- Attempt disconnect() whenever a client was created, even if is_connected is False.