### PR TITLE
fix: split shunt energy into charged and discharged totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-If you want the derived `shunt_energy` value to accumulate across repeated reads,
+If you want the derived shunt energy totals to accumulate across repeated reads,
 reuse a single `ShuntBleClient` instance:
 
 ```python

--- a/src/renogy_ble/__init__.py
+++ b/src/renogy_ble/__init__.py
@@ -27,7 +27,8 @@ from renogy_ble.ble import (
 from renogy_ble.renogy_parser import RenogyParser
 from renogy_ble.shunt import (
     KEY_SHUNT_CURRENT,
-    KEY_SHUNT_ENERGY,
+    KEY_SHUNT_ENERGY_CHARGED_TOTAL,
+    KEY_SHUNT_ENERGY_DISCHARGED_TOTAL,
     KEY_SHUNT_POWER,
     KEY_SHUNT_SOC,
     KEY_SHUNT_VOLTAGE,
@@ -64,7 +65,8 @@ __all__ = [
     "KEY_SHUNT_CURRENT",
     "KEY_SHUNT_POWER",
     "KEY_SHUNT_SOC",
-    "KEY_SHUNT_ENERGY",
+    "KEY_SHUNT_ENERGY_CHARGED_TOTAL",
+    "KEY_SHUNT_ENERGY_DISCHARGED_TOTAL",
     "parse_shunt_payload",
     "ShuntBleClient",
 ]

--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -24,7 +24,8 @@ KEY_SHUNT_VOLTAGE = "shunt_voltage"
 KEY_SHUNT_CURRENT = "shunt_current"
 KEY_SHUNT_POWER = "shunt_power"
 KEY_SHUNT_SOC = "shunt_soc"
-KEY_SHUNT_ENERGY = "shunt_energy"
+KEY_SHUNT_ENERGY_CHARGED_TOTAL = "energy_charged_total"
+KEY_SHUNT_ENERGY_DISCHARGED_TOTAL = "energy_discharged_total"
 
 
 def _bytes_to_number(
@@ -78,7 +79,8 @@ def parse_shunt_payload(payload: bytes) -> dict[str, Any] | None:
         KEY_SHUNT_CURRENT: current,
         KEY_SHUNT_POWER: power,
         KEY_SHUNT_SOC: soc,
-        KEY_SHUNT_ENERGY: None,
+        KEY_SHUNT_ENERGY_CHARGED_TOTAL: None,
+        KEY_SHUNT_ENERGY_DISCHARGED_TOTAL: None,
         "starter_battery_voltage": starter_voltage,
         "battery_temperature": battery_temp,
     }
@@ -116,24 +118,28 @@ class ShuntBleClient:
         self._expected_length = expected_length
         self._max_notification_wait_time = max_notification_wait_time
         self._max_attempts = max_attempts
-        self._energy_state: dict[str, tuple[float, float]] = {}
+        self._energy_state: dict[str, tuple[float, float, float]] = {}
 
-    def _integrate_energy(
+    def _integrate_energy_totals(
         self, *, device_address: str, power_w: float | int | None, now_ts: float
-    ) -> float:
-        """Integrate power over time and return net energy in kWh for one device."""
+    ) -> tuple[float, float]:
+        """Integrate charging and discharging totals in kWh for one device."""
         state = self._energy_state.get(device_address)
         if state is None:
-            self._energy_state[device_address] = (now_ts, 0.0)
-            return 0.0
+            self._energy_state[device_address] = (now_ts, 0.0, 0.0)
+            return 0.0, 0.0
 
-        last_ts, net_wh = state
+        last_ts, charged_wh, discharged_wh = state
         dt_hours = (now_ts - last_ts) / 3600
         if 0 < dt_hours < 10 and power_w is not None:
-            net_wh += float(power_w) * dt_hours
+            energy_wh = float(power_w) * dt_hours
+            if energy_wh >= 0:
+                charged_wh += energy_wh
+            else:
+                discharged_wh += abs(energy_wh)
 
-        self._energy_state[device_address] = (now_ts, net_wh)
-        return net_wh / 1000
+        self._energy_state[device_address] = (now_ts, charged_wh, discharged_wh)
+        return charged_wh / 1000, discharged_wh / 1000
 
     async def read_device(self, device: RenogyBLEDevice) -> RenogyBleReadResult:
         """Connect, wait for one notification payload, parse, and return result."""
@@ -183,12 +189,15 @@ class ShuntBleClient:
 
             if parsed_result and raw_payload:
                 now = loop.time()
-                net_kwh = self._integrate_energy(
+                charged_kwh, discharged_kwh = self._integrate_energy_totals(
                     device_address=device.address,
                     power_w=parsed_result.get(KEY_SHUNT_POWER),
                     now_ts=now,
                 )
-                parsed_result[KEY_SHUNT_ENERGY] = round(net_kwh, 3)
+                parsed_result[KEY_SHUNT_ENERGY_CHARGED_TOTAL] = round(charged_kwh, 3)
+                parsed_result[KEY_SHUNT_ENERGY_DISCHARGED_TOTAL] = round(
+                    discharged_kwh, 3
+                )
 
                 parsed_result["raw_payload"] = raw_payload.hex()
                 parsed_result["raw_words"] = [

--- a/tests/test_shunt.py
+++ b/tests/test_shunt.py
@@ -7,7 +7,8 @@ from renogy_ble import shunt as shunt_module
 from renogy_ble.ble import RenogyBLEDevice
 from renogy_ble.shunt import (
     KEY_SHUNT_CURRENT,
-    KEY_SHUNT_ENERGY,
+    KEY_SHUNT_ENERGY_CHARGED_TOTAL,
+    KEY_SHUNT_ENERGY_DISCHARGED_TOTAL,
     KEY_SHUNT_POWER,
     KEY_SHUNT_SOC,
     KEY_SHUNT_VOLTAGE,
@@ -39,7 +40,8 @@ def test_parse_shunt_payload_returns_expected_fields() -> None:
     assert data[KEY_SHUNT_CURRENT] == -5.4
     assert data[KEY_SHUNT_POWER] == round(13.2 * -5.4, 2)
     assert data[KEY_SHUNT_SOC] == 85.4
-    assert data[KEY_SHUNT_ENERGY] is None
+    assert data[KEY_SHUNT_ENERGY_CHARGED_TOTAL] is None
+    assert data[KEY_SHUNT_ENERGY_DISCHARGED_TOTAL] is None
     assert data["battery_temperature"] == 24.5
 
 
@@ -75,39 +77,43 @@ def test_find_valid_payload_window_recovers_from_misaligned_frame() -> None:
     assert parsed[KEY_SHUNT_CURRENT] == 4.3
 
 
-def test_energy_integration_tracks_each_device_separately() -> None:
-    """Validate energy integration state is isolated per device address."""
+def test_energy_integration_tracks_totals_for_each_device_separately() -> None:
+    """Validate energy totals are isolated per device address."""
     client = ShuntBleClient()
 
-    assert (
-        client._integrate_energy(device_address="A", power_w=100.0, now_ts=1000.0) == 0
-    )
-    assert (
-        client._integrate_energy(device_address="B", power_w=200.0, now_ts=1100.0) == 0
-    )
+    assert client._integrate_energy_totals(
+        device_address="A", power_w=100.0, now_ts=1000.0
+    ) == (0, 0)
+    assert client._integrate_energy_totals(
+        device_address="B", power_w=200.0, now_ts=1100.0
+    ) == (0, 0)
 
-    a_energy = client._integrate_energy(
+    a_charged, a_discharged = client._integrate_energy_totals(
         device_address="A", power_w=100.0, now_ts=4600.0
     )
-    b_energy = client._integrate_energy(
-        device_address="B", power_w=200.0, now_ts=2900.0
+    b_charged, b_discharged = client._integrate_energy_totals(
+        device_address="B", power_w=-200.0, now_ts=2900.0
     )
 
-    assert round(a_energy, 3) == 0.1
-    assert round(b_energy, 3) == 0.1
+    assert round(a_charged, 3) == 0.1
+    assert round(a_discharged, 3) == 0
+    assert round(b_charged, 3) == 0
+    assert round(b_discharged, 3) == 0.1
 
 
 def test_energy_integration_ignores_invalid_time_delta() -> None:
-    """Validate integration does not accumulate for stale or non-positive deltas."""
+    """Validate energy totals do not accumulate for stale or non-positive deltas."""
     client = ShuntBleClient()
 
-    assert (
-        client._integrate_energy(device_address="A", power_w=50.0, now_ts=1000.0) == 0
-    )
-    assert client._integrate_energy(device_address="A", power_w=50.0, now_ts=900.0) == 0
-    assert (
-        client._integrate_energy(device_address="A", power_w=50.0, now_ts=50000.0) == 0
-    )
+    assert client._integrate_energy_totals(
+        device_address="A", power_w=50.0, now_ts=1000.0
+    ) == (0, 0)
+    assert client._integrate_energy_totals(
+        device_address="A", power_w=50.0, now_ts=900.0
+    ) == (0, 0)
+    assert client._integrate_energy_totals(
+        device_address="A", power_w=50.0, now_ts=50000.0
+    ) == (0, 0)
 
 
 def _mock_ble_device(name: str = "RTMShunt300A", address: str = "AA:BB:CC:DD:EE:FF"):


### PR DESCRIPTION
## Summary
- replace the net Smart Shunt energy value with separate charged and discharged totals
- export the new shunt keys and update the README wording
- update shunt tests to validate per-device monotonic charge and discharge accumulation

## Testing
- uv run ruff format .
- uv run ruff check . --output-format=github
- uv run ty check . --output-format=github
- uv run pytest tests