### PR TITLE
ci: rerun prerelease on release please updates

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,8 @@ name: Prerelease
 on:
   pull_request:
     branches: [main]
-    types: [opened]
+    # Run when the Release Please PR is created and whenever its branch is updated.
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       release_branch:


### PR DESCRIPTION
## Summary
- trigger the prerelease workflow on Release Please PR updates
- keep the existing guard so only `release-please--*` PRs publish betas

## Testing
- not run (GitHub Actions workflow change only)