### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_call: # Makes this workflow reusable
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/IAmTheMitchell/renogy-ble/security/code-scanning/1](https://github.com/IAmTheMitchell/renogy-ble/security/code-scanning/1)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions either at the workflow root (affecting all jobs that don't override it) or directly under the `test` job. The minimal safe choice for this workflow is to allow only read access to repository contents, since the job just checks out code and runs tests/lints without pushing changes or modifying issues/PRs.

The best fix without changing existing functionality is to add a top-level `permissions` block just after the `on:` section. In `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

at the workflow level (aligned with `name`, `on`, `concurrency`, `jobs`). This ensures that the `test` job (and any other jobs in this workflow) run with a read-only `GITHUB_TOKEN` for repository contents, satisfying CodeQL and following least-privilege principles. No additional imports, methods, or definitions are required; it is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
