### PR TITLE
fix: harden smart shunt live packet parsing

### DIFF
--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -99,24 +99,26 @@ def parse_shunt_payload(payload: bytes) -> dict[str, Any] | None:
     }
 
 
-def _extract_live_payload_window(payload: bytes, expected_length: int) -> bytes | None:
-    """Return a normalized live-data payload window from the stream head."""
-    if len(payload) >= expected_length and payload.startswith(SHUNT_LIVE_HEADER):
-        return payload[:expected_length]
+def _extract_live_payload_window(
+    payload: bytes, offset: int, expected_length: int
+) -> bytes | None:
+    """Return a normalized live-data payload window from the given stream offset."""
+    payload_length = len(payload)
+    if (
+        payload_length >= offset + expected_length
+        and payload[offset : offset + len(SHUNT_LIVE_HEADER)] == SHUNT_LIVE_HEADER
+    ):
+        return payload[offset : offset + expected_length]
 
     framed_length = expected_length + SHUNT_FRAMED_PREFIX_LENGTH
+    framed_offset = offset + SHUNT_FRAMED_PREFIX_LENGTH
     if (
-        len(payload) >= framed_length
-        and payload.startswith(SHUNT_FRAMED_PREFIX)
-        and payload[
-            SHUNT_FRAMED_PREFIX_LENGTH : SHUNT_FRAMED_PREFIX_LENGTH
-            + len(SHUNT_LIVE_HEADER)
-        ]
+        payload_length >= offset + framed_length
+        and payload[offset : offset + len(SHUNT_FRAMED_PREFIX)] == SHUNT_FRAMED_PREFIX
+        and payload[framed_offset : framed_offset + len(SHUNT_LIVE_HEADER)]
         == SHUNT_LIVE_HEADER
     ):
-        return payload[
-            SHUNT_FRAMED_PREFIX_LENGTH : SHUNT_FRAMED_PREFIX_LENGTH + expected_length
-        ]
+        return payload[framed_offset : framed_offset + expected_length]
 
     return None
 
@@ -130,7 +132,7 @@ def _find_valid_payload_window(
 
     max_offset = len(payload) - expected_length
     for offset in range(max_offset + 1):
-        window = _extract_live_payload_window(payload[offset:], expected_length)
+        window = _extract_live_payload_window(payload, offset, expected_length)
         if window is None:
             continue
         parsed = parse_shunt_payload(window)

--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -22,6 +22,7 @@ SHUNT_EXPECTED_PAYLOAD_LENGTH = 110
 SHUNT_LIVE_HEADER = bytes.fromhex("42570119")
 SHUNT_FRAMED_PREFIX = bytes.fromhex("61d2")
 SHUNT_FRAMED_PREFIX_LENGTH = 4
+SHUNT_REQUIRED_FIELD_LENGTH = 28
 
 KEY_SHUNT_VOLTAGE = "shunt_voltage"
 KEY_SHUNT_CURRENT = "shunt_current"
@@ -55,7 +56,7 @@ def _bytes_to_number(
 
 def parse_shunt_payload(payload: bytes) -> dict[str, Any] | None:
     """Parse a raw Smart Shunt notification frame."""
-    if len(payload) < SHUNT_EXPECTED_PAYLOAD_LENGTH:
+    if len(payload) < SHUNT_REQUIRED_FIELD_LENGTH:
         return None
     if not payload.startswith(SHUNT_LIVE_HEADER):
         return None

--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -19,6 +19,9 @@ SHUNT_NOTIFY_CHAR_UUID = "0000c411-0000-1000-8000-00805f9b34fb"
 
 # Smart Shunt payload size from empirical captures.
 SHUNT_EXPECTED_PAYLOAD_LENGTH = 110
+SHUNT_LIVE_HEADER = bytes.fromhex("42570119")
+SHUNT_FRAMED_PREFIX = bytes.fromhex("61d2")
+SHUNT_FRAMED_PREFIX_LENGTH = 4
 
 KEY_SHUNT_VOLTAGE = "shunt_voltage"
 KEY_SHUNT_CURRENT = "shunt_current"
@@ -26,6 +29,8 @@ KEY_SHUNT_POWER = "shunt_power"
 KEY_SHUNT_SOC = "shunt_soc"
 KEY_SHUNT_ENERGY_CHARGED_TOTAL = "energy_charged_total"
 KEY_SHUNT_ENERGY_DISCHARGED_TOTAL = "energy_discharged_total"
+KEY_SHUNT_DECODE_CONFIDENCE = "decode_confidence"
+KEY_SHUNT_READING_VERIFIED = "reading_verified"
 
 
 def _bytes_to_number(
@@ -50,6 +55,11 @@ def _bytes_to_number(
 
 def parse_shunt_payload(payload: bytes) -> dict[str, Any] | None:
     """Parse a raw Smart Shunt notification frame."""
+    if len(payload) < SHUNT_EXPECTED_PAYLOAD_LENGTH:
+        return None
+    if not payload.startswith(SHUNT_LIVE_HEADER):
+        return None
+
     voltage = _bytes_to_number(payload, 25, 3, scale=0.001, decimals=2)
     starter_voltage = _bytes_to_number(payload, 30, 2, scale=0.001, decimals=2)
     current = _bytes_to_number(payload, 21, 3, signed=True, scale=0.001, decimals=2)
@@ -81,9 +91,33 @@ def parse_shunt_payload(payload: bytes) -> dict[str, Any] | None:
         KEY_SHUNT_SOC: soc,
         KEY_SHUNT_ENERGY_CHARGED_TOTAL: None,
         KEY_SHUNT_ENERGY_DISCHARGED_TOTAL: None,
+        KEY_SHUNT_DECODE_CONFIDENCE: "live_header",
+        KEY_SHUNT_READING_VERIFIED: True,
         "starter_battery_voltage": starter_voltage,
         "battery_temperature": battery_temp,
     }
+
+
+def _extract_live_payload_window(payload: bytes, expected_length: int) -> bytes | None:
+    """Return a normalized live-data payload window from the stream head."""
+    if len(payload) >= expected_length and payload.startswith(SHUNT_LIVE_HEADER):
+        return payload[:expected_length]
+
+    framed_length = expected_length + SHUNT_FRAMED_PREFIX_LENGTH
+    if (
+        len(payload) >= framed_length
+        and payload.startswith(SHUNT_FRAMED_PREFIX)
+        and payload[
+            SHUNT_FRAMED_PREFIX_LENGTH : SHUNT_FRAMED_PREFIX_LENGTH
+            + len(SHUNT_LIVE_HEADER)
+        ]
+        == SHUNT_LIVE_HEADER
+    ):
+        return payload[
+            SHUNT_FRAMED_PREFIX_LENGTH : SHUNT_FRAMED_PREFIX_LENGTH + expected_length
+        ]
+
+    return None
 
 
 def _find_valid_payload_window(
@@ -95,7 +129,9 @@ def _find_valid_payload_window(
 
     max_offset = len(payload) - expected_length
     for offset in range(max_offset + 1):
-        window = payload[offset : offset + expected_length]
+        window = _extract_live_payload_window(payload[offset:], expected_length)
+        if window is None:
+            continue
         parsed = parse_shunt_payload(window)
         if parsed is not None:
             return window, parsed
@@ -149,7 +185,6 @@ class ShuntBleClient:
         success = False
         parsed_result: dict[str, Any] | None = None
         raw_payload: bytes | None = None
-        device.parsed_data.clear()
 
         try:
             client = await establish_connection(
@@ -178,7 +213,10 @@ class ShuntBleClient:
                 remaining = self._max_notification_wait_time - (loop.time() - start)
                 if remaining <= 0:
                     break
-                await asyncio.wait_for(event.wait(), remaining)
+                try:
+                    await asyncio.wait_for(event.wait(), remaining)
+                except asyncio.TimeoutError:
+                    break
                 event.clear()
 
                 maybe_parsed = _find_valid_payload_window(

--- a/tests/test_shunt.py
+++ b/tests/test_shunt.py
@@ -7,11 +7,14 @@ from renogy_ble import shunt as shunt_module
 from renogy_ble.ble import RenogyBLEDevice
 from renogy_ble.shunt import (
     KEY_SHUNT_CURRENT,
+    KEY_SHUNT_DECODE_CONFIDENCE,
     KEY_SHUNT_ENERGY_CHARGED_TOTAL,
     KEY_SHUNT_ENERGY_DISCHARGED_TOTAL,
     KEY_SHUNT_POWER,
+    KEY_SHUNT_READING_VERIFIED,
     KEY_SHUNT_SOC,
     KEY_SHUNT_VOLTAGE,
+    SHUNT_LIVE_HEADER,
     ShuntBleClient,
     _find_valid_payload_window,
     parse_shunt_payload,
@@ -19,10 +22,15 @@ from renogy_ble.shunt import (
 
 
 def _build_payload(
-    voltage: float = 13.2, current: float = -5.4, starter_voltage: float = 13.1
+    voltage: float = 13.2,
+    current: float = -5.4,
+    starter_voltage: float = 13.1,
+    *,
+    header: bytes = SHUNT_LIVE_HEADER,
 ) -> bytes:
     """Build a synthetic 110-byte Smart Shunt payload."""
     payload = bytearray(110)
+    payload[0 : len(header)] = header
     payload[25:28] = int(voltage * 1000).to_bytes(3, "big", signed=False)
     payload[21:24] = int(current * 1000).to_bytes(3, "big", signed=True)
     payload[30:32] = int(starter_voltage * 1000).to_bytes(2, "big", signed=False)
@@ -42,7 +50,15 @@ def test_parse_shunt_payload_returns_expected_fields() -> None:
     assert data[KEY_SHUNT_SOC] == 85.4
     assert data[KEY_SHUNT_ENERGY_CHARGED_TOTAL] is None
     assert data[KEY_SHUNT_ENERGY_DISCHARGED_TOTAL] is None
+    assert data[KEY_SHUNT_DECODE_CONFIDENCE] == "live_header"
+    assert data[KEY_SHUNT_READING_VERIFIED] is True
     assert data["battery_temperature"] == 24.5
+
+
+def test_parse_shunt_payload_rejects_non_live_header() -> None:
+    """Validate non-live 4257 subtype frames are rejected."""
+    data = parse_shunt_payload(_build_payload(header=bytes.fromhex("4257010b")))
+    assert data is None
 
 
 def test_parse_shunt_payload_rejects_out_of_range_voltage() -> None:
@@ -75,6 +91,38 @@ def test_find_valid_payload_window_recovers_from_misaligned_frame() -> None:
     assert raw_payload == valid_payload
     assert parsed[KEY_SHUNT_VOLTAGE] == 13.2
     assert parsed[KEY_SHUNT_CURRENT] == 4.3
+
+
+def test_find_valid_payload_window_prefers_live_frame_over_history_frame() -> None:
+    """Validate history frames are skipped until a live payload is found."""
+    history_payload = _build_payload(
+        voltage=13.4, current=1.1, header=bytes.fromhex("4257010b")
+    )
+    live_payload = _build_payload(voltage=14.2, current=5.6)
+
+    result = _find_valid_payload_window(
+        history_payload + b"\xaa\xbb" + live_payload, expected_length=110
+    )
+
+    assert result is not None
+    raw_payload, parsed = result
+    assert raw_payload == live_payload
+    assert parsed[KEY_SHUNT_VOLTAGE] == 14.2
+    assert parsed[KEY_SHUNT_CURRENT] == 5.6
+
+
+def test_find_valid_payload_window_strips_framed_live_packet() -> None:
+    """Validate the parser strips the observed 61d2 framing prefix."""
+    live_payload = _build_payload(voltage=13.9, current=2.4)
+    framed_payload = bytes.fromhex("61d20000") + live_payload
+
+    result = _find_valid_payload_window(framed_payload, expected_length=110)
+
+    assert result is not None
+    raw_payload, parsed = result
+    assert raw_payload == live_payload
+    assert parsed[KEY_SHUNT_VOLTAGE] == 13.9
+    assert parsed[KEY_SHUNT_CURRENT] == 2.4
 
 
 def test_energy_integration_tracks_totals_for_each_device_separately() -> None:
@@ -125,8 +173,8 @@ def _mock_ble_device(name: str = "RTMShunt300A", address: str = "AA:BB:CC:DD:EE:
     return device
 
 
-def test_read_device_clears_stale_data_on_connection_failure(monkeypatch) -> None:
-    """Validate failed reads do not return stale parsed data."""
+def test_read_device_preserves_stale_data_on_connection_failure(monkeypatch) -> None:
+    """Validate failed reads preserve the last known good parsed data."""
 
     async def _fake_establish_connection(*_args, **_kwargs):
         raise asyncio.TimeoutError("connect timeout")
@@ -143,8 +191,8 @@ def test_read_device_clears_stale_data_on_connection_failure(monkeypatch) -> Non
 
     assert result.success is False
     assert isinstance(result.error, asyncio.TimeoutError)
-    assert result.parsed_data == {}
-    assert device.parsed_data == {}
+    assert result.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
+    assert device.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
 
 
 def test_read_device_parses_misaligned_notification_stream(monkeypatch) -> None:
@@ -183,3 +231,45 @@ def test_read_device_parses_misaligned_notification_stream(monkeypatch) -> None:
     assert result.error is None
     assert result.parsed_data[KEY_SHUNT_VOLTAGE] == 14.1
     assert result.parsed_data[KEY_SHUNT_CURRENT] == 3.2
+
+
+def test_read_device_preserves_last_good_data_on_history_only_payload(
+    monkeypatch,
+) -> None:
+    """Validate non-live payloads do not overwrite the last good reading."""
+    history_payload = _build_payload(
+        voltage=14.8, current=4.1, header=bytes.fromhex("4257010b")
+    )
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.is_connected = True
+            self._notify_handler = None
+
+        async def start_notify(self, _uuid, handler):
+            self._notify_handler = handler
+            self._notify_handler(1, bytearray(history_payload))
+
+        async def stop_notify(self, *_args, **_kwargs):
+            return None
+
+        async def disconnect(self):
+            self.is_connected = False
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return DummyClient()
+
+    monkeypatch.setattr(
+        shunt_module, "establish_connection", _fake_establish_connection
+    )
+
+    client = ShuntBleClient(max_notification_wait_time=0.01)
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="SHUNT300")
+    device.parsed_data = {"shunt_voltage": 13.2, "raw_payload": "last-good"}
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is False
+    assert isinstance(result.error, RuntimeError)
+    assert result.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "last-good"}
+    assert device.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "last-good"}

--- a/tests/test_shunt.py
+++ b/tests/test_shunt.py
@@ -27,15 +27,19 @@ def _build_payload(
     starter_voltage: float = 13.1,
     *,
     header: bytes = SHUNT_LIVE_HEADER,
+    length: int = 110,
 ) -> bytes:
     """Build a synthetic 110-byte Smart Shunt payload."""
-    payload = bytearray(110)
+    payload = bytearray(length)
     payload[0 : len(header)] = header
     payload[25:28] = int(voltage * 1000).to_bytes(3, "big", signed=False)
     payload[21:24] = int(current * 1000).to_bytes(3, "big", signed=True)
-    payload[30:32] = int(starter_voltage * 1000).to_bytes(2, "big", signed=False)
-    payload[34:36] = int(85.4 * 10).to_bytes(2, "big", signed=False)
-    payload[66:68] = int(24.5 * 10).to_bytes(2, "big", signed=False)
+    if length >= 32:
+        payload[30:32] = int(starter_voltage * 1000).to_bytes(2, "big", signed=False)
+    if length >= 36:
+        payload[34:36] = int(85.4 * 10).to_bytes(2, "big", signed=False)
+    if length >= 68:
+        payload[66:68] = int(24.5 * 10).to_bytes(2, "big", signed=False)
     return bytes(payload)
 
 
@@ -77,6 +81,16 @@ def test_parse_shunt_payload_rejects_short_payload() -> None:
     """Validate short payloads are rejected."""
     data = parse_shunt_payload(bytes([0x00] * 12))
     assert data is None
+
+
+def test_parse_shunt_payload_accepts_short_live_frame() -> None:
+    """Validate shorter live frames still parse when required fields exist."""
+    data = parse_shunt_payload(_build_payload(voltage=12.8, current=3.1, length=28))
+
+    assert data is not None
+    assert data[KEY_SHUNT_VOLTAGE] == 12.8
+    assert data[KEY_SHUNT_CURRENT] == 3.1
+    assert data["battery_temperature"] is None
 
 
 def test_find_valid_payload_window_recovers_from_misaligned_frame() -> None:
@@ -123,6 +137,19 @@ def test_find_valid_payload_window_strips_framed_live_packet() -> None:
     assert raw_payload == live_payload
     assert parsed[KEY_SHUNT_VOLTAGE] == 13.9
     assert parsed[KEY_SHUNT_CURRENT] == 2.4
+
+
+def test_find_valid_payload_window_supports_shorter_expected_length() -> None:
+    """Validate the configurable expected length still works for shorter live frames."""
+    live_payload = _build_payload(voltage=12.6, current=-1.8, length=28)
+
+    result = _find_valid_payload_window(live_payload, expected_length=28)
+
+    assert result is not None
+    raw_payload, parsed = result
+    assert raw_payload == live_payload
+    assert parsed[KEY_SHUNT_VOLTAGE] == 12.6
+    assert parsed[KEY_SHUNT_CURRENT] == -1.8
 
 
 def test_energy_integration_tracks_totals_for_each_device_separately() -> None:


### PR DESCRIPTION
## Summary
- require the confirmed `42570119` smart shunt live-data header before parsing
- strip the observed `61d2` framing prefix in the library before surfacing raw payload/words
- preserve the last good shunt reading when a new payload is invalid and add regression coverage for history/live selection

## Testing
- uv run ruff format .
- uv run ruff check . --output-format=github
- uv run ty check . --output-format=github
- uv run pytest tests

Closes rbl-jrw.