### PR TITLE
chore: ignore Beads credential key runtime file

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -10,6 +10,7 @@ last-touched
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version
+.beads-credential-key
 
 # Worktree redirect file (contains relative path to main repo's .beads/)
 # Must not be committed as paths would be wrong in other clones


### PR DESCRIPTION
## Summary
- ignore `.beads/.beads-credential-key` in `.beads/.gitignore`
- keep the local Beads credential secret out of git status and accidental commits

## Testing
- `git check-ignore -v .beads/.beads-credential-key`
- `git status --short`

Refs: rbl-0w2