### PR TITLE
fix: rewrite inverter read flow

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -30,6 +30,7 @@ MAX_NOTIFICATION_WAIT_TIME = 2.0
 
 # Default device ID for Renogy devices
 DEFAULT_DEVICE_ID = 0xFF
+INVERTER_DEVICE_ID = 0x20
 
 # Default device type
 DEFAULT_DEVICE_TYPE = "controller"
@@ -39,6 +40,12 @@ DEFAULT_TRANSPORT_MODE = "per_operation"
 
 # Controller register for DC load control
 LOAD_CONTROL_REGISTER = 0x010A
+
+# Inverter-specific BLE setup
+INVERTER_INIT_CHAR_UUID = "0000ffd4-0000-1000-8000-00805f9b34fb"
+INVERTER_INIT_DELAY = 1.0
+INVERTER_INTER_COMMAND_DELAY = 0.3
+INVERTER_COMMAND_TIMEOUT = 10.0
 
 # Modbus commands for requesting data
 # Format: (function_code, start_register, word_count)
@@ -358,6 +365,17 @@ class RenogyBleWriteResult:
 TransportMode = Literal["per_operation", "persistent_session"]
 
 
+@dataclass(frozen=True, slots=True)
+class _InverterReadSpec:
+    """Describe one validated inverter Modbus read."""
+
+    register: int
+    word_count: int
+    parser_name: str
+    retries: int = 1
+    cache_key: str | None = None
+
+
 @dataclass(slots=True)
 class _PersistentBleSession:
     """Track a persistent BLE connection for a single device."""
@@ -417,6 +435,9 @@ class RenogyBleClient:
                 max_attempts=self._max_attempts,
             )
             return await shunt_client.read_device(device)
+
+        if device.device_type == "inverter":
+            return await self._read_inverter_device(device)
 
         commands = self._commands.get(device.device_type)
         if not commands:
@@ -533,6 +554,258 @@ class RenogyBleClient:
             return RenogyBleReadResult(
                 any_command_succeeded, dict(device.parsed_data), error
             )
+
+    async def _read_inverter_device(
+        self, device: RenogyBLEDevice
+    ) -> RenogyBleReadResult:
+        """Read inverter data using the validated session transport."""
+        session = await self._prepare_session(device)
+        cached_data = dict(device.parsed_data)
+
+        async with session.lock:
+            try:
+                await self._ensure_session_ready(device, session)
+            except Exception as connection_error:
+                logger.info(
+                    "Failed to prepare BLE session for inverter %s: %s",
+                    device.name,
+                    str(connection_error),
+                )
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=True,
+                )
+                return RenogyBleReadResult(
+                    False, dict(device.parsed_data), connection_error
+                )
+
+            any_command_succeeded = False
+            error: Exception | None = None
+
+            try:
+                logger.debug("Connected to inverter %s", device.name)
+                if session.client is None:
+                    raise RuntimeError("BLE session is not connected")
+
+                await asyncio.sleep(INVERTER_INIT_DELAY)
+
+                try:
+                    await session.client.read_gatt_char(INVERTER_INIT_CHAR_UUID)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "Inverter init read failed for %s: %s", device.name, exc
+                    )
+
+                parsed_updates: dict[str, Any] = {}
+                read_specs = (
+                    _InverterReadSpec(
+                        4000, 32, "_parse_inverter_main_response", retries=2
+                    ),
+                    _InverterReadSpec(4408, 6, "_parse_inverter_load_response"),
+                    _InverterReadSpec(
+                        4109,
+                        1,
+                        "_parse_inverter_device_id_response",
+                        cache_key="device_id",
+                    ),
+                    _InverterReadSpec(
+                        4311,
+                        8,
+                        "_parse_inverter_model_response",
+                        cache_key="model",
+                    ),
+                )
+
+                for index, spec in enumerate(read_specs):
+                    if index > 0:
+                        await asyncio.sleep(INVERTER_INTER_COMMAND_DELAY)
+
+                    if spec.cache_key is not None and spec.cache_key in cached_data:
+                        parsed_updates[spec.cache_key] = cached_data[spec.cache_key]
+                        continue
+
+                    result_data = await self._read_modbus_register(
+                        session,
+                        device_id=INVERTER_DEVICE_ID,
+                        function_code=0x03,
+                        register=spec.register,
+                        word_count=spec.word_count,
+                        cmd_name=f"inverter register {spec.register}",
+                        device_name=device.name,
+                        timeout=INVERTER_COMMAND_TIMEOUT,
+                        retries=spec.retries,
+                    )
+                    if result_data is None:
+                        continue
+
+                    parser = getattr(self, spec.parser_name)
+                    parsed = parser(result_data)
+                    if not parsed:
+                        logger.info(
+                            "Failed to parse inverter register %s from device %s",
+                            spec.register,
+                            device.name,
+                        )
+                        continue
+
+                    parsed_updates.update(parsed)
+                    any_command_succeeded = True
+
+                if parsed_updates:
+                    device.parsed_data.update(parsed_updates)
+
+                if not any_command_succeeded:
+                    error = RuntimeError("No inverter commands completed successfully")
+            except BleakError as exc:
+                logger.info("BLE error with inverter %s: %s", device.name, str(exc))
+                error = exc
+            except Exception as exc:
+                logger.error(
+                    "Error reading inverter data from device %s: %s",
+                    device.name,
+                    str(exc),
+                )
+                error = exc
+
+            if error is not None:
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=True,
+                )
+            elif self._transport_mode != "persistent_session":
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=False,
+                )
+
+            return RenogyBleReadResult(
+                any_command_succeeded, dict(device.parsed_data), error
+            )
+
+    async def _read_modbus_register(
+        self,
+        session: _PersistentBleSession,
+        *,
+        device_id: int,
+        function_code: int,
+        register: int,
+        word_count: int,
+        cmd_name: str,
+        device_name: str,
+        timeout: float,
+        retries: int = 1,
+    ) -> bytes | None:
+        """Send a validated Modbus read request and return its response."""
+        request = create_modbus_read_request(
+            device_id,
+            function_code,
+            register,
+            word_count,
+        )
+
+        for attempt in range(retries):
+            self._reset_notifications(session)
+            if session.client is None:
+                raise RuntimeError("BLE session is not connected")
+            await session.client.write_gatt_char(self._write_char_uuid, request)
+
+            try:
+                return await self._wait_for_valid_read_response(
+                    session,
+                    function_code=function_code,
+                    word_count=word_count,
+                    cmd_name=cmd_name,
+                    device_name=device_name,
+                    expected_device_id=device_id,
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                if attempt < retries - 1:
+                    logger.debug(
+                        "Timeout waiting for %s from device %s. Retrying (%s/%s).",
+                        cmd_name,
+                        device_name,
+                        attempt + 2,
+                        retries,
+                    )
+                    continue
+
+        return None
+
+    @staticmethod
+    def _parse_inverter_main_response(data: bytes) -> dict[str, Any]:
+        """Parse Modbus response from inverter register 4000."""
+        if len(data) < 5:
+            logger.warning("Inverter response too short: %d bytes", len(data))
+            return {}
+
+        values = [
+            int.from_bytes(data[index : index + 2], "big")
+            for index in range(3, len(data) - 2, 2)
+        ]
+        if len(values) < 10:
+            logger.warning("Not enough inverter register values: %d", len(values))
+            return {}
+
+        return {
+            "ac_input_voltage": values[0] * 0.1,
+            "ac_input_current": values[1] * 0.01,
+            "ac_output_voltage": values[2] * 0.1,
+            "ac_output_current": values[3] * 0.01,
+            "ac_output_frequency": values[4] * 0.01,
+            "battery_voltage": values[5] * 0.1,
+            "temperature": values[6] * 0.1,
+            "input_frequency": values[9] * 0.01,
+        }
+
+    @staticmethod
+    def _parse_inverter_load_response(data: bytes) -> dict[str, Any]:
+        """Parse Modbus response from inverter register 4408."""
+        if len(data) < 11:
+            logger.warning("Inverter load response too short: %d bytes", len(data))
+            return {}
+
+        values = [
+            int.from_bytes(data[index : index + 2], "big")
+            for index in range(3, len(data) - 2, 2)
+        ]
+        if len(values) < 3:
+            logger.warning("Not enough inverter load values: %d", len(values))
+            return {}
+
+        return {
+            "load_current": values[0] * 0.01,
+            "load_active_power": values[1],
+            "load_apparent_power": values[2],
+        }
+
+    @staticmethod
+    def _parse_inverter_device_id_response(data: bytes) -> dict[str, Any]:
+        """Parse Modbus response from inverter register 4109."""
+        if len(data) < 7:
+            logger.warning("Inverter device id response too short: %d bytes", len(data))
+            return {}
+
+        return {"device_id": int.from_bytes(data[3:5], "big")}
+
+    @staticmethod
+    def _parse_inverter_model_response(data: bytes) -> dict[str, Any]:
+        """Parse Modbus response from inverter register 4311."""
+        if len(data) < 21:
+            logger.warning("Inverter model response too short: %d bytes", len(data))
+            return {}
+
+        model = data[3:19].decode("ascii", errors="ignore").rstrip("\x00").strip()
+        if not model:
+            return {}
+
+        return {"model": model}
 
     async def write_single_register(
         self,
@@ -772,10 +1045,14 @@ class RenogyBleClient:
         self,
         notification_data: bytes | bytearray,
         *,
+        expected_device_id: int | None = None,
         function_code: int,
         word_count: int,
     ) -> bytes | None:
         """Return the latest valid Modbus read frame from buffered notifications."""
+        device_id = (
+            self._device_id if expected_device_id is None else expected_device_id
+        )
         expected_payload_bytes = word_count * 2
         expected_len = 3 + expected_payload_bytes + 2
         max_offset = len(notification_data) - expected_len
@@ -786,7 +1063,7 @@ class RenogyBleClient:
         latest_candidate: bytes | None = None
         for offset in range(max_offset + 1):
             candidate = bytes(notification_data[offset : offset + expected_len])
-            if candidate[0] != self._device_id or candidate[1] != function_code:
+            if candidate[0] != device_id or candidate[1] != function_code:
                 continue
             if candidate[2] != expected_payload_bytes:
                 continue
@@ -829,27 +1106,29 @@ class RenogyBleClient:
         self,
         session: _PersistentBleSession,
         *,
+        expected_device_id: int | None = None,
         function_code: int,
         word_count: int,
         cmd_name: str,
         device_name: str,
+        timeout: float | None = None,
     ) -> bytes:
         """Wait for a valid Modbus read frame in buffered notifications."""
         expected_len = 3 + word_count * 2 + 2
         start_time = asyncio.get_running_loop().time()
+        max_wait = self._max_notification_wait_time if timeout is None else timeout
 
         while True:
             response = self._extract_valid_read_response(
                 session.notification_data,
+                expected_device_id=expected_device_id,
                 function_code=function_code,
                 word_count=word_count,
             )
             if response is not None:
                 return response
 
-            remaining = self._max_notification_wait_time - (
-                asyncio.get_running_loop().time() - start_time
-            )
+            remaining = max_wait - (asyncio.get_running_loop().time() - start_time)
             if remaining <= 0:
                 logger.info(
                     "Timeout – no valid %s frame after %s bytes from device %s",

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from renogy_ble.ble import (
     DEFAULT_DEVICE_ID,
+    INVERTER_DEVICE_ID,
     UNAVAILABLE_RETRY_INTERVAL,
     BleakError,
     RenogyBleClient,
@@ -25,6 +26,25 @@ def _mock_ble_device(name="BT-TH-TEST", address="AA:BB:CC:DD:EE:FF"):
     device.address = address
     device.rssi = -60
     return device
+
+
+def _modbus_read_response(device_id: int, register_values: list[int]) -> bytes:
+    payload = bytearray([device_id, 0x03, len(register_values) * 2])
+    for value in register_values:
+        payload.extend(value.to_bytes(2, "big"))
+    crc_low, crc_high = modbus_crc(payload)
+    payload.extend([crc_low, crc_high])
+    return bytes(payload)
+
+
+def _modbus_ascii_response(device_id: int, value: str, register_count: int) -> bytes:
+    encoded = value.encode("ascii")
+    payload_bytes = encoded.ljust(register_count * 2, b"\x00")
+    payload = bytearray([device_id, 0x03, len(payload_bytes)])
+    payload.extend(payload_bytes)
+    crc_low, crc_high = modbus_crc(payload)
+    payload.extend([crc_low, crc_high])
+    return bytes(payload)
 
 
 def test_modbus_crc_known_vector():
@@ -231,6 +251,182 @@ def test_read_device_shunt300_reports_error_when_shunt_module_missing(monkeypatc
 
     assert result.success is False
     assert isinstance(result.error, ImportError)
+
+
+def test_read_device_reads_inverter_data_with_validated_frames(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+            responses = {
+                4000: _modbus_read_response(
+                    INVERTER_DEVICE_ID,
+                    [2300, 125, 2295, 250, 6000, 401, 255, 0, 0, 5995] + ([0] * 22),
+                ),
+                4408: _modbus_read_response(
+                    INVERTER_DEVICE_ID, [175, 500, 550, 0, 0, 0]
+                ),
+                4109: _modbus_read_response(INVERTER_DEVICE_ID, [32]),
+                4311: _modbus_ascii_response(INVERTER_DEVICE_ID, "RIV1220PU-126", 8),
+            }
+            response = responses[register]
+            wrong_device = response.replace(
+                bytes([INVERTER_DEVICE_ID]),
+                bytes([DEFAULT_DEVICE_ID]),
+                1,
+            )
+            self._notify_handler(None, wrong_device + response)
+
+        async def read_gatt_char(self, *_args, **_kwargs):
+            return b"\x00"
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="RNGRIU123456"), device_type="inverter"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.error is None
+    assert result.parsed_data == {
+        "ac_input_voltage": 230.0,
+        "ac_input_current": 1.25,
+        "ac_output_voltage": 229.5,
+        "ac_output_current": 2.5,
+        "ac_output_frequency": 60.0,
+        "battery_voltage": 40.1,
+        "temperature": 25.5,
+        "input_frequency": 59.95,
+        "load_current": 1.75,
+        "load_active_power": 500,
+        "load_apparent_power": 550,
+        "device_id": 32,
+        "model": "RIV1220PU-126",
+    }
+    assert [request[0] for request in dummy_client.writes] == [INVERTER_DEVICE_ID] * 4
+    assert dummy_client.stop_notify_calls == 1
+    assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(
+    monkeypatch,
+):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.start_notify_calls = 0
+            self.stop_notify_calls = 0
+            self.read_gatt_char_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self.start_notify_calls += 1
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+            responses = {
+                4000: _modbus_read_response(
+                    INVERTER_DEVICE_ID,
+                    [2300, 100, 2290, 200, 6000, 402, 260, 0, 0, 6000] + ([0] * 22),
+                ),
+                4408: _modbus_read_response(
+                    INVERTER_DEVICE_ID, [150, 450, 475, 0, 0, 0]
+                ),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def read_gatt_char(self, *_args, **_kwargs):
+            self.read_gatt_char_calls += 1
+            return b"\x00"
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+    establish_calls = 0
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        nonlocal establish_calls
+        establish_calls += 1
+        dummy_client.is_connected = True
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(transport_mode="persistent_session")
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="RNGRIU123456"), device_type="inverter"
+    )
+    device.parsed_data = {"device_id": 32, "model": "RIV1220PU-126"}
+
+    async def _run() -> tuple[dict[str, object], dict[str, object]]:
+        first = await client.read_device(device)
+        second = await client.read_device(device)
+        await client.close_device(device)
+        return first.parsed_data, second.parsed_data
+
+    first_data, second_data = asyncio.run(_run())
+
+    assert establish_calls == 1
+    assert dummy_client.start_notify_calls == 1
+    assert dummy_client.stop_notify_calls == 1
+    assert dummy_client.disconnect_calls == 1
+    assert dummy_client.read_gatt_char_calls == 2
+    assert [int.from_bytes(request[2:4], "big") for request in dummy_client.writes] == [
+        4000,
+        4408,
+        4000,
+        4408,
+    ]
+    assert first_data["device_id"] == 32
+    assert first_data["model"] == "RIV1220PU-126"
+    assert second_data["device_id"] == 32
+    assert second_data["model"] == "RIV1220PU-126"
 
 
 def test_persistent_session_reuses_connection_for_reads(monkeypatch):


### PR DESCRIPTION
## Summary
Rewrites inverter Modbus read flow using known-good register sequence (4000/4408/4109/4311).
Preserves inverter values across partial reads.
Adds inverter device id constant for Modbus requests.
