### PR TITLE
fix: avoid cached client for Smart Shunt reads

### DIFF
--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -198,6 +198,7 @@ class ShuntBleClient:
                 device.ble_device,
                 device.name or device.address,
                 max_attempts=self._max_attempts,
+                use_services_cache=False,
             )
         except (BleakError, asyncio.TimeoutError) as exc:
             logger.info("Failed to connect to Smart Shunt %s: %s", device.address, exc)

--- a/src/renogy_ble/shunt.py
+++ b/src/renogy_ble/shunt.py
@@ -6,9 +6,10 @@ import asyncio
 import logging
 from typing import Any
 
+from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
-from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from bleak_retry_connector import establish_connection
 
 from renogy_ble.ble import RenogyBLEDevice, RenogyBleReadResult
 
@@ -191,7 +192,9 @@ class ShuntBleClient:
 
         try:
             client = await establish_connection(
-                BleakClientWithServiceCache,
+                # Smart Shunt reconnects can present a fresh characteristic object
+                # path, so avoid reusing cached service state for each read.
+                BleakClient,
                 device.ble_device,
                 device.name or device.address,
                 max_attempts=self._max_attempts,

--- a/tests/test_shunt.py
+++ b/tests/test_shunt.py
@@ -205,10 +205,13 @@ def _mock_ble_device(name: str = "RTMShunt300A", address: str = "AA:BB:CC:DD:EE:
 def test_read_device_preserves_stale_data_on_connection_failure(monkeypatch) -> None:
     """Validate failed reads preserve the last known good parsed data."""
     connection_client_class = None
+    connection_kwargs = None
 
     async def _fake_establish_connection(client_class, *_args, **_kwargs):
         nonlocal connection_client_class
+        nonlocal connection_kwargs
         connection_client_class = client_class
+        connection_kwargs = _kwargs
         raise asyncio.TimeoutError("connect timeout")
 
     monkeypatch.setattr(
@@ -226,6 +229,8 @@ def test_read_device_preserves_stale_data_on_connection_failure(monkeypatch) -> 
     assert result.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
     assert device.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
     assert connection_client_class is BleakClient
+    assert connection_kwargs is not None
+    assert connection_kwargs["use_services_cache"] is False
 
 
 def test_read_device_parses_misaligned_notification_stream(monkeypatch) -> None:

--- a/tests/test_shunt.py
+++ b/tests/test_shunt.py
@@ -3,6 +3,8 @@
 import asyncio
 from unittest.mock import MagicMock
 
+from bleak import BleakClient
+
 from renogy_ble import shunt as shunt_module
 from renogy_ble.ble import RenogyBLEDevice
 from renogy_ble.shunt import (
@@ -202,8 +204,11 @@ def _mock_ble_device(name: str = "RTMShunt300A", address: str = "AA:BB:CC:DD:EE:
 
 def test_read_device_preserves_stale_data_on_connection_failure(monkeypatch) -> None:
     """Validate failed reads preserve the last known good parsed data."""
+    connection_client_class = None
 
-    async def _fake_establish_connection(*_args, **_kwargs):
+    async def _fake_establish_connection(client_class, *_args, **_kwargs):
+        nonlocal connection_client_class
+        connection_client_class = client_class
         raise asyncio.TimeoutError("connect timeout")
 
     monkeypatch.setattr(
@@ -220,6 +225,7 @@ def test_read_device_preserves_stale_data_on_connection_failure(monkeypatch) -> 
     assert isinstance(result.error, asyncio.TimeoutError)
     assert result.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
     assert device.parsed_data == {"shunt_voltage": 13.2, "raw_payload": "stale"}
+    assert connection_client_class is BleakClient
 
 
 def test_read_device_parses_misaligned_notification_stream(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- switch `ShuntBleClient` to plain `BleakClient` for Smart Shunt read connections
- keep the existing shunt payload parsing path unchanged, including current `61d2` handling
- add a regression test that asserts the shunt read path no longer passes `BleakClientWithServiceCache` into `establish_connection`

## Testing
- `uv run ruff format .`
- `uv run ruff check . --output-format=github`
- `uv run ty check . --output-format=github`
- `uv run pytest tests`

Refs: rbl-7jl