### PR TITLE
ci: refresh uv.lock for release PRs

### DIFF
--- a/.github/workflows/release-lockfile.yml
+++ b/.github/workflows/release-lockfile.yml
@@ -1,0 +1,46 @@
+name: Refresh Release Lockfile
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+
+jobs:
+  refresh-lockfile:
+    if: ${{ startsWith(github.event.pull_request.head.ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Refresh lockfile
+        run: uv lock
+
+      - name: Commit updated lockfile
+        run: |
+          if git diff --quiet -- uv.lock; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: refresh uv.lock for release PR"
+          git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Set up Python
         run: uv python install
 
+      - name: Check lockfile
+        run: uv lock --check
+
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --locked --all-extras --dev
 
       - name: Run tests
         run: uv run pytest tests

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
## Summary
- fail CI when `uv.lock` is stale by adding `uv lock --check`
- use `uv sync --locked` in the test workflow
- auto-refresh `uv.lock` on `release-please--*` PR branches before merge
- update the checked-in lockfile metadata to match the current package version

## Why
Release Please bumps `pyproject.toml`, but it does not regenerate `uv.lock`. That leaves the editable root package entry stale and breaks locked installs.

## Validation
- `uv lock --check`
- `uv sync --locked --all-extras --dev`
- `uv run pytest tests`
- `uv run ruff check . --output-format=github`
- `uv run ty check . --output-format=github`
