### PR TITLE
fix: validate CRC on Modbus read responses to prevent corrupt sensor values

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -284,6 +284,22 @@ class RenogyBLEDevice:
                 )
                 return False
 
+            # Validate the CRC of the read response. The CRC covers all bytes
+            # except the final two, which carry the low and high CRC bytes.
+            payload_len = 3 + byte_count
+            crc_low, crc_high = modbus_crc(raw_data[:payload_len])
+            if raw_data[payload_len : payload_len + 2] != bytes([crc_low, crc_high]):
+                logger.warning(
+                    "CRC mismatch for %s (register %s): expected %02x %02x, got %s. "
+                    "Discarding frame to avoid corrupt sensor values.",
+                    cmd_name,
+                    register,
+                    crc_low,
+                    crc_high,
+                    raw_data[payload_len : payload_len + 2].hex(),
+                )
+                return False
+
             parsed = RenogyParser.parse(raw_data, self.device_type, register)
 
             if not parsed:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -388,3 +388,99 @@ def test_write_single_register_cleans_up_when_notify_setup_raises_runtime_error(
     assert str(result.error) == "notify setup failed"
     assert dummy_client.stop_notify_calls == 0
     assert dummy_client.disconnect_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# CRC validation on read responses
+# ---------------------------------------------------------------------------
+
+
+def _make_read_frame(data_bytes: bytes) -> bytes:
+    """Build a well-formed Modbus read-response frame with a correct CRC.
+
+    Frame layout: [device_id, func_code, byte_count, <data_bytes>, crc_low, crc_high]
+    """
+    header = bytes([DEFAULT_DEVICE_ID, 0x03, len(data_bytes)])
+    payload = header + data_bytes
+    crc_low, crc_high = modbus_crc(payload)
+    return payload + bytes([crc_low, crc_high])
+
+
+def test_update_parsed_data_accepts_valid_crc(monkeypatch):
+    """A frame whose CRC matches its content must be parsed and accepted."""
+    frame = _make_read_frame(bytes([0x00, 0x50, 0x00, 0x00]))
+
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="controller")
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(
+        ble_module.RenogyParser,
+        "parse",
+        lambda *_args, **_kwargs: {"battery_voltage": 12.5},
+    )
+
+    result = device.update_parsed_data(frame, register=256, cmd_name="status")
+
+    assert result is True
+    assert device.parsed_data.get("battery_voltage") == 12.5
+
+
+def test_update_parsed_data_rejects_corrupted_crc(monkeypatch):
+    """A frame with a bad CRC must be rejected before the parser is ever called."""
+    frame = _make_read_frame(bytes([0x00, 0x50, 0x00, 0x00]))
+
+    # Flip the low CRC byte to produce a mismatch.
+    bad_frame = frame[:-2] + bytes([frame[-2] ^ 0xFF, frame[-1]])
+
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="controller")
+
+    from renogy_ble import ble as ble_module
+
+    parse_called = []
+    monkeypatch.setattr(
+        ble_module.RenogyParser,
+        "parse",
+        lambda *_args, **_kwargs: (
+            parse_called.append(True) or {"battery_voltage": 99999.0}
+        ),
+    )
+
+    result = device.update_parsed_data(bad_frame, register=256, cmd_name="status")
+
+    assert result is False
+    assert parse_called == [], "Parser must not be called when CRC is invalid"
+    assert "battery_voltage" not in device.parsed_data
+
+
+def test_update_parsed_data_rejects_bit_flipped_payload(monkeypatch):
+    """A bit-flip anywhere in the data bytes must be caught by the CRC check.
+
+    This simulates the real-world scenario where BLE corruption turns a normal
+    voltage register value into a kilovolt-range reading.
+    """
+    # 0x00 0x50 encodes 8.0 V (scale 0.1); 0xFF 0xFF would encode 6553.5 V.
+    frame = _make_read_frame(bytes([0x00, 0x50, 0x00, 0x00]))
+
+    # Flip the first data byte — the original CRC is now wrong.
+    corrupted = bytearray(frame)
+    corrupted[3] = 0xFF
+    bad_frame = bytes(corrupted)
+
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="controller")
+    device.parsed_data["battery_voltage"] = 13.0  # pre-existing valid reading
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(
+        ble_module.RenogyParser,
+        "parse",
+        # What the parser would return if corruption were not caught.
+        lambda *_args, **_kwargs: {"battery_voltage": 6553.5},
+    )
+
+    result = device.update_parsed_data(bad_frame, register=256, cmd_name="status")
+
+    assert result is False
+    # The pre-existing valid reading must be preserved, not overwritten with garbage.
+    assert device.parsed_data.get("battery_voltage") == 13.0


### PR DESCRIPTION
## Problem

Read responses from BLE devices were accepted and parsed **without verifying their CRC**. Write responses already performed the same check correctly. Because BLE is an inherently noisy medium, a single bit-flip anywhere in a response payload could silently produce impossible values — kilovolt voltages, kiloamp currents — that propagated directly to any consumer of the parsed data (e.g. Home Assistant sensor entities).

Concretely, for a controller like the Wanderer 10A:
- Battery voltage register: 2 bytes, scale 0.1. Bytes `0xFF 0xFF` → **6553.5 V**
- Battery current register: 2 bytes, scale 0.01. Bytes `0xFF 0xFF` → **655.35 A**

These were observed appearing as real sensor readings in Home Assistant.

## Fix

Add CRC validation in `RenogyBLEDevice.update_parsed_data()` using the existing `modbus_crc()` helper, mirroring the pattern already used for write responses. Frames whose CRC does not match are discarded and `False` is returned before the parser is ever called.

```python
payload_len = 3 + byte_count
crc_low, crc_high = modbus_crc(raw_data[:payload_len])
if raw_data[payload_len : payload_len + 2] != bytes([crc_low, crc_high]):
    logger.warning("CRC mismatch for %s ...")
    return False
```

## Tests

Three new tests in `tests/test_ble.py` prove the fix works:

- **`test_update_parsed_data_accepts_valid_crc`** — a well-formed frame with correct CRC is parsed and accepted.
- **`test_update_parsed_data_rejects_corrupted_crc`** — a frame with a flipped CRC byte is rejected *and the parser is never called*.
- **`test_update_parsed_data_rejects_bit_flipped_payload`** — a bit-flip in the data bytes (simulating the real-world corruption scenario) is caught, and any pre-existing valid sensor value is preserved rather than overwritten with garbage.

All 50 existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)