### PR TITLE
fix: validate Modbus read frames before parsing

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -468,24 +468,22 @@ class RenogyBleClient:
                     )
 
                     word_count = cmd[2]
-                    expected_len = 3 + word_count * 2 + 2
 
                     try:
-                        await self._wait_for_notification_bytes(
+                        result_data = await self._wait_for_valid_read_response(
                             session,
-                            expected_len,
-                            cmd_name,
-                            device.name,
+                            function_code=cmd[0],
+                            word_count=word_count,
+                            cmd_name=cmd_name,
+                            device_name=device.name,
                         )
                     except asyncio.TimeoutError:
                         continue
 
-                    result_data = bytes(session.notification_data[:expected_len])
                     logger.debug(
-                        "Received %s data length: %s (expected %s)",
+                        "Received valid %s data length: %s",
                         cmd_name,
                         len(result_data),
-                        expected_len,
                     )
 
                     cmd_success = device.update_parsed_data(
@@ -770,6 +768,36 @@ class RenogyBleClient:
         session.notification_data.clear()
         session.notification_event.clear()
 
+    def _extract_valid_read_response(
+        self,
+        notification_data: bytes | bytearray,
+        *,
+        function_code: int,
+        word_count: int,
+    ) -> bytes | None:
+        """Return the first valid Modbus read frame from buffered notifications."""
+        expected_payload_bytes = word_count * 2
+        expected_len = 3 + expected_payload_bytes + 2
+        max_offset = len(notification_data) - expected_len
+
+        if max_offset < 0:
+            return None
+
+        for offset in range(max_offset + 1):
+            candidate = bytes(notification_data[offset : offset + expected_len])
+            if candidate[0] != self._device_id or candidate[1] != function_code:
+                continue
+            if candidate[2] != expected_payload_bytes:
+                continue
+
+            crc_low, crc_high = modbus_crc(candidate[:-2])
+            if candidate[-2:] != bytes([crc_low, crc_high]):
+                continue
+
+            return candidate
+
+        return None
+
     async def _wait_for_notification_bytes(
         self,
         session: _PersistentBleSession,
@@ -793,6 +821,43 @@ class RenogyBleClient:
                     device_name,
                 )
                 raise asyncio.TimeoutError()
+            await asyncio.wait_for(session.notification_event.wait(), remaining)
+            session.notification_event.clear()
+
+    async def _wait_for_valid_read_response(
+        self,
+        session: _PersistentBleSession,
+        *,
+        function_code: int,
+        word_count: int,
+        cmd_name: str,
+        device_name: str,
+    ) -> bytes:
+        """Wait for a valid Modbus read frame in buffered notifications."""
+        expected_len = 3 + word_count * 2 + 2
+        start_time = asyncio.get_running_loop().time()
+
+        while True:
+            response = self._extract_valid_read_response(
+                session.notification_data,
+                function_code=function_code,
+                word_count=word_count,
+            )
+            if response is not None:
+                return response
+
+            remaining = self._max_notification_wait_time - (
+                asyncio.get_running_loop().time() - start_time
+            )
+            if remaining <= 0:
+                logger.info(
+                    "Timeout – no valid %s frame after %s bytes from device %s",
+                    cmd_name,
+                    max(len(session.notification_data), expected_len),
+                    device_name,
+                )
+                raise asyncio.TimeoutError()
+
             await asyncio.wait_for(session.notification_event.wait(), remaining)
             session.notification_event.clear()
 

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -775,7 +775,7 @@ class RenogyBleClient:
         function_code: int,
         word_count: int,
     ) -> bytes | None:
-        """Return the first valid Modbus read frame from buffered notifications."""
+        """Return the latest valid Modbus read frame from buffered notifications."""
         expected_payload_bytes = word_count * 2
         expected_len = 3 + expected_payload_bytes + 2
         max_offset = len(notification_data) - expected_len
@@ -783,6 +783,7 @@ class RenogyBleClient:
         if max_offset < 0:
             return None
 
+        latest_candidate: bytes | None = None
         for offset in range(max_offset + 1):
             candidate = bytes(notification_data[offset : offset + expected_len])
             if candidate[0] != self._device_id or candidate[1] != function_code:
@@ -794,9 +795,9 @@ class RenogyBleClient:
             if candidate[-2:] != bytes([crc_low, crc_high]):
                 continue
 
-            return candidate
+            latest_candidate = candidate
 
-        return None
+        return latest_candidate
 
     async def _wait_for_notification_bytes(
         self,

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -84,6 +84,25 @@ def test_extract_valid_read_response_rejects_invalid_crc():
     assert response is None
 
 
+def test_extract_valid_read_response_prefers_latest_matching_frame():
+    client = RenogyBleClient()
+    stale_payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34])
+    stale_crc_low, stale_crc_high = modbus_crc(stale_payload)
+    stale_frame = stale_payload + bytes([stale_crc_low, stale_crc_high])
+
+    latest_payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x56, 0x78])
+    latest_crc_low, latest_crc_high = modbus_crc(latest_payload)
+    latest_frame = latest_payload + bytes([latest_crc_low, latest_crc_high])
+
+    response = client._extract_valid_read_response(
+        b"\x99\x88" + stale_frame + latest_frame,
+        function_code=0x03,
+        word_count=1,
+    )
+
+    assert response == latest_frame
+
+
 def test_clean_device_name_strips_whitespace():
     assert clean_device_name("  Renogy  BLE\t") == "Renogy BLE"
     assert clean_device_name("") == ""

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -56,6 +56,34 @@ def test_create_modbus_write_request_defaults_function_code():
     assert frame[6:] == bytes([crc_low, crc_high])
 
 
+def test_extract_valid_read_response_skips_junk_prefix():
+    client = RenogyBleClient()
+    payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34])
+    crc_low, crc_high = modbus_crc(payload)
+    valid_frame = payload + bytes([crc_low, crc_high])
+
+    response = client._extract_valid_read_response(
+        b"\x99\x88" + valid_frame,
+        function_code=0x03,
+        word_count=1,
+    )
+
+    assert response == valid_frame
+
+
+def test_extract_valid_read_response_rejects_invalid_crc():
+    client = RenogyBleClient()
+    invalid_frame = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34, 0x00, 0x00])
+
+    response = client._extract_valid_read_response(
+        invalid_frame,
+        function_code=0x03,
+        word_count=1,
+    )
+
+    assert response is None
+
+
 def test_clean_device_name_strips_whitespace():
     assert clean_device_name("  Renogy  BLE\t") == "Renogy BLE"
     assert clean_device_name("") == ""
@@ -103,7 +131,9 @@ def test_read_device_skips_disconnect_when_not_connected(monkeypatch):
             # Provide enough bytes to satisfy expected length (7 bytes).
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
-            self._notify_handler(None, b"\x01\x03\x02\x00\x00\x00\x00")
+            payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x00, 0x00])
+            crc_low, crc_high = modbus_crc(payload)
+            self._notify_handler(None, payload + bytes([crc_low, crc_high]))
 
         async def stop_notify(self, *_args, **_kwargs):
             return None
@@ -200,7 +230,9 @@ def test_persistent_session_reuses_connection_for_reads(monkeypatch):
         async def write_gatt_char(self, *_args, **_kwargs):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
-            self._notify_handler(None, b"\x01\x03\x02\x00\x00\x00\x00")
+            payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x00, 0x00])
+            crc_low, crc_high = modbus_crc(payload)
+            self._notify_handler(None, payload + bytes([crc_low, crc_high]))
 
         async def stop_notify(self, *_args, **_kwargs):
             self.stop_notify_calls += 1
@@ -250,6 +282,65 @@ def test_persistent_session_reuses_connection_for_reads(monkeypatch):
     assert dummy_client.start_notify_calls == 1
     assert dummy_client.stop_notify_calls == 1
     assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_uses_valid_frame_when_notification_has_prefixed_junk(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, *_args, **_kwargs):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+            payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34])
+            crc_low, crc_high = modbus_crc(payload)
+            self._notify_handler(
+                None,
+                b"\x99\x88" + payload + bytes([crc_low, crc_high]),
+            )
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(commands={"test_device": {"status": (3, 0x0000, 1)}})
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="test_device")
+    parsed_frames: list[bytes] = []
+
+    def _update_parsed_data(
+        raw_data: bytes, register: int, cmd_name: str = "unknown"
+    ) -> bool:
+        _ = register, cmd_name
+        parsed_frames.append(raw_data)
+        return True
+
+    monkeypatch.setattr(device, "update_parsed_data", _update_parsed_data)
+
+    result = asyncio.run(client.read_device(device))
+    payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34])
+    crc_low, crc_high = modbus_crc(payload)
+    valid_frame = payload + bytes([crc_low, crc_high])
+
+    assert result.success is True
+    assert parsed_frames == [valid_frame]
 
 
 def test_persistent_session_reuses_connection_for_writes(monkeypatch):


### PR DESCRIPTION
## Summary
- validate read frame boundaries in addition to CRC checks already merged in #72
- scan BLE notification buffers for the first valid Modbus read frame instead of parsing from offset 0
- add regression coverage for junk-prefixed notifications and invalid frame extraction

## Problem
PR #72 fixed corrupted read frames with invalid CRCs. A remaining transport issue is that BLE notifications can contain prefixed junk or stale bytes, and the client previously parsed from offset 0 as soon as enough bytes arrived. That can discard a valid frame later in the buffer or decode the wrong bytes.

## Fix
Search buffered notifications for the first valid Modbus read frame using device id, function code, byte count, and CRC validation before parsing.

## Testing
- uv run ruff check . --output-format=github
- uv run ty check . --output-format=github
- uv run pytest tests