### PR TITLE
[codex] Add Dependabot package cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -13,3 +15,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- add a 7-day Dependabot cooldown for `uv` updates
- add a 7-day Dependabot cooldown for `github-actions` updates
- keep the existing weekly schedule unchanged

## Why
This reduces PR churn by waiting seven days after a dependency release before Dependabot opens an update PR.

## Validation
- reviewed the updated `.github/dependabot.yml` diff locally