### PR TITLE
[codex] Add Renogy battery BLE support

### DIFF
--- a/src/renogy_ble/__init__.py
+++ b/src/renogy_ble/__init__.py
@@ -7,6 +7,13 @@ It supports different device models by routing the parsing to type-specific pars
 
 import logging
 
+from renogy_ble.battery import (
+    BATTERY_DEVICE_TYPE,
+    BATTERY_VARIANT_LEGACY,
+    BATTERY_VARIANT_PRO,
+    detect_battery_variant,
+    is_supported_battery_name,
+)
 from renogy_ble.ble import (
     COMMANDS,
     DEFAULT_DEVICE_ID,
@@ -46,6 +53,9 @@ logging.basicConfig(
 
 __all__ = [
     "COMMANDS",
+    "BATTERY_DEVICE_TYPE",
+    "BATTERY_VARIANT_LEGACY",
+    "BATTERY_VARIANT_PRO",
     "DEFAULT_DEVICE_ID",
     "DEFAULT_DEVICE_TYPE",
     "LOAD_CONTROL_REGISTER",
@@ -60,6 +70,8 @@ __all__ = [
     "clean_device_name",
     "create_modbus_read_request",
     "create_modbus_write_request",
+    "detect_battery_variant",
+    "is_supported_battery_name",
     "modbus_crc",
     "KEY_SHUNT_VOLTAGE",
     "KEY_SHUNT_CURRENT",

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -1,0 +1,211 @@
+"""Helpers for Renogy battery protocol detection and parsing."""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Any, Literal
+
+BATTERY_DEVICE_TYPE = "battery"
+BATTERY_VARIANT_LEGACY = "legacy"
+BATTERY_VARIANT_PRO = "pro"
+BatteryVariant = Literal["legacy", "pro"]
+
+BATTERY_PRO_NAME_PREFIXES = ("RNGRBP", "RNGC")
+BATTERY_LEGACY_NAME_PREFIX = "BT-TH-"
+BATTERY_PRO_MANUFACTURER_ID = 0xE14C
+
+BATTERY_PROTOCOL_DEVICE_IDS: dict[BatteryVariant, int] = {
+    BATTERY_VARIANT_LEGACY: 0x30,
+    BATTERY_VARIANT_PRO: 0xFF,
+}
+
+BATTERY_DEFAULT_MODELS: dict[BatteryVariant, str] = {
+    BATTERY_VARIANT_LEGACY: "Renogy Bluetooth Battery",
+    BATTERY_VARIANT_PRO: "Renogy BT Battery Pro",
+}
+
+# Format: (register, word_count)
+BATTERY_COMMANDS: dict[str, tuple[int, int]] = {
+    "device_info": (0x13F0, 0x1C),
+    "pack_status": (0x13B2, 0x07),
+    "cell_status": (0x1388, 0x22),
+    "mosfet_status": (0x13EC, 0x08),
+}
+
+
+def clean_battery_text(value: bytes) -> str:
+    """Decode ASCII battery metadata and strip padding."""
+    return value.decode("ascii", errors="ignore").strip("\x00").strip()
+
+
+def detect_battery_variant(
+    name: str | None,
+    *,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> BatteryVariant | None:
+    """Return the supported battery protocol variant for the given advertisement."""
+    cleaned_name = (name or "").strip()
+    manufacturer_data = manufacturer_data or {}
+
+    if cleaned_name.startswith(BATTERY_PRO_NAME_PREFIXES):
+        return BATTERY_VARIANT_PRO
+
+    if BATTERY_PRO_MANUFACTURER_ID in manufacturer_data:
+        return BATTERY_VARIANT_PRO
+
+    if cleaned_name.startswith(BATTERY_LEGACY_NAME_PREFIX):
+        return BATTERY_VARIANT_LEGACY
+
+    return None
+
+
+def is_supported_battery_name(name: str | None) -> bool:
+    """Return True when a BLE name matches a supported battery family."""
+    return detect_battery_variant(name) is not None
+
+
+@cache
+def build_battery_command(
+    variant: BatteryVariant, register: int, word_count: int
+) -> bytes:
+    """Build the read request for a battery command."""
+    frame = bytearray(
+        [
+            BATTERY_PROTOCOL_DEVICE_IDS[variant],
+            0x03,
+            (register >> 8) & 0xFF,
+            register & 0xFF,
+            (word_count >> 8) & 0xFF,
+            word_count & 0xFF,
+        ]
+    )
+    crc_low, crc_high = modbus_crc(frame)
+    frame.extend([crc_low, crc_high])
+    return bytes(frame)
+
+
+def modbus_crc(data: bytes | bytearray) -> tuple[int, int]:
+    """Calculate the Modbus CRC16 of the given data."""
+    crc = 0xFFFF
+    for pos in data:
+        crc ^= pos
+        for _ in range(8):
+            if crc & 0x0001:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return (crc & 0xFF, (crc >> 8) & 0xFF)
+
+
+def parse_battery_device_info(
+    data: bytes,
+    *,
+    variant: BatteryVariant,
+) -> dict[str, Any]:
+    """Parse the battery metadata frame."""
+    parsed: dict[str, Any] = {
+        "battery_variant": variant,
+        "model": BATTERY_DEFAULT_MODELS[variant],
+    }
+
+    serial_number = clean_battery_text(data[15:31])
+    if serial_number:
+        parsed["serial_number"] = serial_number
+
+    battery_name = clean_battery_text(data[39:55])
+    if battery_name:
+        parsed["device_name"] = battery_name
+
+    sw_version = clean_battery_text(data[55:59])
+    if sw_version:
+        parsed["sw_version"] = sw_version
+
+    return parsed
+
+
+def parse_battery_pack_status(
+    data: bytes,
+    *,
+    variant: BatteryVariant,
+) -> dict[str, Any]:
+    """Parse the battery summary status frame."""
+    current_scale = 0.1 if variant == BATTERY_VARIANT_PRO else 0.01
+    battery_voltage = int.from_bytes(data[5:7], byteorder="big") / 10
+    battery_current = int.from_bytes(data[3:5], byteorder="big", signed=True) / (
+        10 if variant == BATTERY_VARIANT_PRO else 100
+    )
+    battery_remaining_capacity = int.from_bytes(data[7:11], byteorder="big") / 1000
+    battery_capacity = int.from_bytes(data[11:15], byteorder="big") // 1000
+    battery_cycle_count = int.from_bytes(data[15:17], byteorder="big")
+
+    parsed: dict[str, Any] = {
+        "battery_variant": variant,
+        "battery_voltage": round(battery_voltage, 1),
+        "battery_current": round(battery_current, 2 if current_scale == 0.01 else 1),
+        "battery_remaining_capacity": round(battery_remaining_capacity, 3),
+        "battery_capacity": battery_capacity,
+        "battery_cycle_count": battery_cycle_count,
+        "battery_power": round(battery_voltage * battery_current, 3),
+    }
+
+    if battery_capacity > 0:
+        parsed["battery_percentage"] = round(
+            (battery_remaining_capacity / battery_capacity) * 100, 1
+        )
+
+    return parsed
+
+
+def parse_battery_cell_status(
+    data: bytes,
+    *,
+    variant: BatteryVariant,
+) -> dict[str, Any]:
+    """Parse cell voltages and temperature sensors."""
+    _ = variant
+    parsed: dict[str, Any] = {}
+
+    cell_count = int.from_bytes(data[3:5], byteorder="big")
+    parsed["cell_count"] = cell_count
+
+    cell_values = [
+        int.from_bytes(data[start : start + 2], byteorder="big") / 10
+        for start in range(5, 5 + min(cell_count, 16) * 2, 2)
+    ]
+    if cell_values:
+        parsed["cell_voltages"] = cell_values
+        parsed["cell_voltage_min"] = min(cell_values)
+        parsed["cell_voltage_max"] = max(cell_values)
+        parsed["cell_voltage_delta"] = round(max(cell_values) - min(cell_values), 3)
+
+    temp_sensor_count = int.from_bytes(data[37:39], byteorder="big")
+    parsed["battery_temperature_sensors"] = temp_sensor_count
+
+    temp_values = [
+        int.from_bytes(data[start : start + 2], byteorder="big", signed=True) / 10
+        for start in range(39, 39 + min(temp_sensor_count, 16) * 2, 2)
+    ]
+    if temp_values:
+        parsed["battery_temperature_values"] = temp_values
+        parsed["battery_temperature"] = round(sum(temp_values) / len(temp_values), 1)
+        parsed["battery_temperature_min"] = min(temp_values)
+        parsed["battery_temperature_max"] = max(temp_values)
+
+    return parsed
+
+
+def parse_battery_mosfet_status(
+    data: bytes,
+    *,
+    variant: BatteryVariant,
+) -> dict[str, Any]:
+    """Parse fault and MOSFET flags."""
+    _ = variant
+    problem_code = int.from_bytes(data[3:17], byteorder="big") & (~0xE)
+
+    return {
+        "battery_problem_code": problem_code,
+        "charge_mosfet_enabled": bool(data[16] & 0x2),
+        "discharge_mosfet_enabled": bool(data[16] & 0x4),
+        "heater_enabled": bool(data[17] & 0x20),
+    }

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -182,8 +182,9 @@ def parse_battery_cell_status(
     cell_count = int.from_bytes(data[3:5], byteorder="big")
     parsed["cell_count"] = cell_count
 
+    # Cell voltage registers are reported in millivolts.
     cell_values = [
-        int.from_bytes(data[start : start + 2], byteorder="big") / 10
+        int.from_bytes(data[start : start + 2], byteorder="big") / 1000
         for start in range(5, 5 + min(cell_count, 16) * 2, 2)
     ]
     if cell_values:

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -149,7 +149,7 @@ def parse_battery_pack_status(
         10 if variant == BATTERY_VARIANT_PRO else 100
     )
     battery_remaining_capacity = int.from_bytes(data[7:11], byteorder="big") / 1000
-    battery_capacity = int.from_bytes(data[11:15], byteorder="big") // 1000
+    battery_capacity = int.from_bytes(data[11:15], byteorder="big") / 1000
     battery_cycle_count = int.from_bytes(data[15:17], byteorder="big")
 
     parsed: dict[str, Any] = {

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -12,6 +12,7 @@ BatteryVariant = Literal["legacy", "pro"]
 
 BATTERY_PRO_NAME_PREFIXES = ("RNGRBP", "RNGC")
 BATTERY_LEGACY_NAME_PREFIX = "BT-TH-"
+BATTERY_LEGACY_NAME_MARKERS = ("BATT", "BATTERY")
 BATTERY_PRO_MANUFACTURER_ID = 0xE14C
 
 BATTERY_PROTOCOL_DEVICE_IDS: dict[BatteryVariant, int] = {
@@ -53,15 +54,28 @@ def detect_battery_variant(
     if BATTERY_PRO_MANUFACTURER_ID in manufacturer_data:
         return BATTERY_VARIANT_PRO
 
-    if cleaned_name.startswith(BATTERY_LEGACY_NAME_PREFIX):
+    if _is_legacy_battery_name(cleaned_name):
         return BATTERY_VARIANT_LEGACY
 
     return None
 
 
-def is_supported_battery_name(name: str | None) -> bool:
-    """Return True when a BLE name matches a supported battery family."""
-    return detect_battery_variant(name) is not None
+def is_supported_battery_name(
+    name: str | None,
+    *,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> bool:
+    """Return True when an advertisement matches a supported battery family."""
+    return detect_battery_variant(name, manufacturer_data=manufacturer_data) is not None
+
+
+def _is_legacy_battery_name(name: str) -> bool:
+    """Return True only for legacy battery advertisements, not shared BT-TH devices."""
+    if not name.startswith(BATTERY_LEGACY_NAME_PREFIX):
+        return False
+
+    suffix = name[len(BATTERY_LEGACY_NAME_PREFIX) :].upper()
+    return any(marker in suffix for marker in BATTERY_LEGACY_NAME_MARKERS)
 
 
 @cache

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -626,14 +626,17 @@ class RenogyBleClient:
 
                     request = build_battery_command(variant, register, word_count)
                     await session.client.write_gatt_char(self._write_char_uuid, request)
-                    result_data = await self._wait_for_valid_read_response(
-                        session,
-                        expected_device_id=device_id,
-                        function_code=0x03,
-                        word_count=word_count,
-                        cmd_name=f"battery {cmd_name}",
-                        device_name=device.name,
-                    )
+                    try:
+                        result_data = await self._wait_for_valid_read_response(
+                            session,
+                            expected_device_id=device_id,
+                            function_code=0x03,
+                            word_count=word_count,
+                            cmd_name=f"battery {cmd_name}",
+                            device_name=device.name,
+                        )
+                    except asyncio.TimeoutError:
+                        continue
 
                     parser = {
                         "device_info": parse_battery_device_info,

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -607,6 +607,24 @@ class RenogyBleClient:
         """Read data from a supported Renogy battery."""
         session = await self._prepare_session(device)
         cached_data = dict(device.parsed_data)
+        variant = device.battery_variant or detect_battery_variant(
+            device.name,
+            manufacturer_data=device.manufacturer_data,
+        )
+        stable_data: dict[str, Any] = {
+            key: cached_data[key]
+            for key in ("serial_number", "device_name", "sw_version")
+            if key in cached_data
+        }
+        if variant is not None:
+            stable_data["battery_variant"] = variant
+            stable_data["model"] = cached_data.get(
+                "model", BATTERY_DEFAULT_MODELS[variant]
+            )
+
+        # Battery reads should not return stale telemetry from the previous poll.
+        device.parsed_data.clear()
+        device.parsed_data.update(stable_data)
 
         async with session.lock:
             try:
@@ -631,10 +649,6 @@ class RenogyBleClient:
             error: Exception | None = None
 
             try:
-                variant = device.battery_variant or detect_battery_variant(
-                    device.name,
-                    manufacturer_data=device.manufacturer_data,
-                )
                 if variant is None:
                     raise ValueError(
                         f"Unable to determine Renogy battery variant for {device.name}"
@@ -643,19 +657,7 @@ class RenogyBleClient:
                 device.battery_variant = variant
                 # Battery polls should only expose telemetry refreshed during this read.
                 # Preserve stable metadata that can be reused across polls.
-                parsed_updates: dict[str, Any] = {
-                    key: cached_data[key]
-                    for key in ("serial_number", "device_name", "sw_version")
-                    if key in cached_data
-                }
-                parsed_updates.update(
-                    {
-                        "battery_variant": variant,
-                        "model": cached_data.get(
-                            "model", BATTERY_DEFAULT_MODELS[variant]
-                        ),
-                    }
-                )
+                parsed_updates = dict(device.parsed_data)
                 device_id = BATTERY_PROTOCOL_DEVICE_IDS[variant]
 
                 for cmd_name, (register, word_count) in BATTERY_COMMANDS.items():

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -14,6 +14,19 @@ from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 
+from renogy_ble.battery import (
+    BATTERY_COMMANDS,
+    BATTERY_DEFAULT_MODELS,
+    BATTERY_DEVICE_TYPE,
+    BATTERY_PROTOCOL_DEVICE_IDS,
+    BatteryVariant,
+    build_battery_command,
+    detect_battery_variant,
+    parse_battery_cell_status,
+    parse_battery_device_info,
+    parse_battery_mosfet_status,
+    parse_battery_pack_status,
+)
 from renogy_ble.renogy_parser import RenogyParser
 
 logger = logging.getLogger(__name__)
@@ -177,6 +190,11 @@ class RenogyBLEDevice:
         self.parsed_data: dict[str, Any] = {}
         self.device_type = device_type
         self.last_unavailable_time: Optional[datetime] = None
+        self.battery_variant: BatteryVariant | None = (
+            detect_battery_variant(self.name)
+            if device_type == BATTERY_DEVICE_TYPE
+            else None
+        )
 
     @property
     def is_available(self) -> bool:
@@ -419,6 +437,9 @@ class RenogyBleClient:
 
     async def read_device(self, device: RenogyBLEDevice) -> RenogyBleReadResult:
         """Connect to a device, fetch data, and return parsed results."""
+        if device.device_type == BATTERY_DEVICE_TYPE:
+            return await self._read_battery_device(device)
+
         if device.device_type == "shunt300":
             try:
                 from renogy_ble.shunt import ShuntBleClient
@@ -533,6 +554,123 @@ class RenogyBleClient:
             except Exception as exc:
                 logger.error(
                     "Error reading data from device %s: %s", device.name, str(exc)
+                )
+                error = exc
+
+            if error is not None:
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=True,
+                )
+            elif self._transport_mode != "persistent_session":
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=False,
+                )
+
+            return RenogyBleReadResult(
+                any_command_succeeded, dict(device.parsed_data), error
+            )
+
+    async def _read_battery_device(
+        self, device: RenogyBLEDevice
+    ) -> RenogyBleReadResult:
+        """Read data from a supported Renogy battery."""
+        session = await self._prepare_session(device)
+        cached_data = dict(device.parsed_data)
+
+        async with session.lock:
+            try:
+                await self._ensure_session_ready(device, session)
+            except Exception as connection_error:
+                logger.info(
+                    "Failed to prepare BLE session for battery %s: %s",
+                    device.name,
+                    str(connection_error),
+                )
+                await self._close_session(
+                    device.address,
+                    device.name,
+                    session,
+                    remove=True,
+                )
+                return RenogyBleReadResult(
+                    False, dict(device.parsed_data), connection_error
+                )
+
+            any_command_succeeded = False
+            error: Exception | None = None
+
+            try:
+                variant = device.battery_variant or detect_battery_variant(device.name)
+                if variant is None:
+                    raise ValueError(
+                        f"Unable to determine Renogy battery variant for {device.name}"
+                    )
+
+                device.battery_variant = variant
+                parsed_updates: dict[str, Any] = {
+                    "battery_variant": variant,
+                    "model": cached_data.get("model", BATTERY_DEFAULT_MODELS[variant]),
+                }
+                device_id = BATTERY_PROTOCOL_DEVICE_IDS[variant]
+
+                for cmd_name, (register, word_count) in BATTERY_COMMANDS.items():
+                    self._reset_notifications(session)
+                    if session.client is None:
+                        raise RuntimeError("BLE session is not connected")
+
+                    request = build_battery_command(variant, register, word_count)
+                    await session.client.write_gatt_char(self._write_char_uuid, request)
+                    result_data = await self._wait_for_valid_read_response(
+                        session,
+                        expected_device_id=device_id,
+                        function_code=0x03,
+                        word_count=word_count,
+                        cmd_name=f"battery {cmd_name}",
+                        device_name=device.name,
+                    )
+
+                    parser = {
+                        "device_info": parse_battery_device_info,
+                        "pack_status": parse_battery_pack_status,
+                        "cell_status": parse_battery_cell_status,
+                        "mosfet_status": parse_battery_mosfet_status,
+                    }[cmd_name]
+                    parsed = parser(result_data, variant=variant)
+                    if not parsed:
+                        logger.info(
+                            "Failed to parse battery command %s from device %s",
+                            cmd_name,
+                            device.name,
+                        )
+                        continue
+
+                    parsed_updates.update(parsed)
+                    any_command_succeeded = True
+
+                if parsed_updates:
+                    if (
+                        "device_name" in parsed_updates
+                        and parsed_updates["device_name"]
+                    ):
+                        device.name = str(parsed_updates["device_name"])
+                    device.parsed_data.update(parsed_updates)
+
+                if not any_command_succeeded:
+                    error = RuntimeError("No battery commands completed successfully")
+            except BleakError as exc:
+                logger.info("BLE error with battery %s: %s", device.name, str(exc))
+                error = exc
+            except Exception as exc:
+                logger.error(
+                    "Error reading battery data from device %s: %s",
+                    device.name,
+                    str(exc),
                 )
                 error = exc
 

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -164,6 +164,27 @@ def clean_device_name(name: str | None) -> str:
     return ""
 
 
+def extract_manufacturer_data(
+    ble_device: BLEDevice,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> dict[int, bytes]:
+    """Return advertisement manufacturer data stored on the BLE device."""
+    if manufacturer_data is not None:
+        return dict(manufacturer_data)
+
+    direct_data = getattr(ble_device, "manufacturer_data", None)
+    if isinstance(direct_data, dict):
+        return dict(direct_data)
+
+    details = getattr(ble_device, "details", None)
+    if isinstance(details, dict):
+        details_data = details.get("manufacturer_data")
+        if isinstance(details_data, dict):
+            return dict(details_data)
+
+    return {}
+
+
 class RenogyBLEDevice:
     """Representation of a Renogy BLE device."""
 
@@ -172,6 +193,7 @@ class RenogyBLEDevice:
         ble_device: BLEDevice,
         advertisement_rssi: Optional[int] = None,
         device_type: str = DEFAULT_DEVICE_TYPE,
+        manufacturer_data: dict[int, bytes] | None = None,
     ):
         """Initialize the Renogy BLE device."""
         self.ble_device = ble_device
@@ -182,6 +204,9 @@ class RenogyBLEDevice:
 
         # Use the provided advertisement RSSI if available, otherwise set to None.
         self.rssi = advertisement_rssi
+        self.manufacturer_data = extract_manufacturer_data(
+            ble_device, manufacturer_data
+        )
         self.last_seen = datetime.now()
         self.data: Optional[dict[str, Any]] = None
         self.failure_count = 0
@@ -191,7 +216,7 @@ class RenogyBLEDevice:
         self.device_type = device_type
         self.last_unavailable_time: Optional[datetime] = None
         self.battery_variant: BatteryVariant | None = (
-            detect_battery_variant(self.name)
+            detect_battery_variant(self.name, manufacturer_data=self.manufacturer_data)
             if device_type == BATTERY_DEVICE_TYPE
             else None
         )
@@ -606,17 +631,31 @@ class RenogyBleClient:
             error: Exception | None = None
 
             try:
-                variant = device.battery_variant or detect_battery_variant(device.name)
+                variant = device.battery_variant or detect_battery_variant(
+                    device.name,
+                    manufacturer_data=device.manufacturer_data,
+                )
                 if variant is None:
                     raise ValueError(
                         f"Unable to determine Renogy battery variant for {device.name}"
                     )
 
                 device.battery_variant = variant
+                # Battery polls should only expose telemetry refreshed during this read.
+                # Preserve stable metadata that can be reused across polls.
                 parsed_updates: dict[str, Any] = {
-                    "battery_variant": variant,
-                    "model": cached_data.get("model", BATTERY_DEFAULT_MODELS[variant]),
+                    key: cached_data[key]
+                    for key in ("serial_number", "device_name", "sw_version")
+                    if key in cached_data
                 }
+                parsed_updates.update(
+                    {
+                        "battery_variant": variant,
+                        "model": cached_data.get(
+                            "model", BATTERY_DEFAULT_MODELS[variant]
+                        ),
+                    }
+                )
                 device_id = BATTERY_PROTOCOL_DEVICE_IDS[variant]
 
                 for cmd_name, (register, word_count) in BATTERY_COMMANDS.items():
@@ -656,13 +695,9 @@ class RenogyBleClient:
                     parsed_updates.update(parsed)
                     any_command_succeeded = True
 
-                if parsed_updates:
-                    if (
-                        "device_name" in parsed_updates
-                        and parsed_updates["device_name"]
-                    ):
-                        device.name = str(parsed_updates["device_name"])
-                    device.parsed_data.update(parsed_updates)
+                if "device_name" in parsed_updates and parsed_updates["device_name"]:
+                    device.name = str(parsed_updates["device_name"])
+                device.parsed_data = parsed_updates
 
                 if not any_command_succeeded:
                     error = RuntimeError("No battery commands completed successfully")

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,119 @@
+"""Tests for Renogy battery protocol helpers."""
+
+from renogy_ble.battery import (
+    BATTERY_VARIANT_LEGACY,
+    BATTERY_VARIANT_PRO,
+    build_battery_command,
+    detect_battery_variant,
+    parse_battery_cell_status,
+    parse_battery_device_info,
+    parse_battery_mosfet_status,
+    parse_battery_pack_status,
+)
+
+
+def _battery_frame(
+    device_id: int,
+    payload: bytes,
+) -> bytes:
+    from renogy_ble.battery import modbus_crc
+
+    frame = bytearray([device_id, 0x03, len(payload)])
+    frame.extend(payload)
+    crc_low, crc_high = modbus_crc(frame)
+    frame.extend([crc_low, crc_high])
+    return bytes(frame)
+
+
+def test_detect_battery_variant_from_name_and_manufacturer_data() -> None:
+    """Battery detection should distinguish Pro and legacy families."""
+    assert detect_battery_variant("RNGRBP123456") == BATTERY_VARIANT_PRO
+    assert detect_battery_variant("RNGC123456") == BATTERY_VARIANT_PRO
+    assert detect_battery_variant("BT-TH-123456") == BATTERY_VARIANT_LEGACY
+    assert (
+        detect_battery_variant("Unknown", manufacturer_data={0xE14C: b"\x01"})
+        == BATTERY_VARIANT_PRO
+    )
+    assert detect_battery_variant("Other") is None
+
+
+def test_build_battery_command_uses_variant_device_id() -> None:
+    """Battery commands should use the variant-specific response header ID."""
+    legacy = build_battery_command(BATTERY_VARIANT_LEGACY, 0x13B2, 0x0007)
+    pro = build_battery_command(BATTERY_VARIANT_PRO, 0x13B2, 0x0007)
+
+    assert legacy[:6] == bytes([0x30, 0x03, 0x13, 0xB2, 0x00, 0x07])
+    assert pro[:6] == bytes([0xFF, 0x03, 0x13, 0xB2, 0x00, 0x07])
+
+
+def test_parse_battery_device_info() -> None:
+    """Battery device info should expose serial, name, and software version."""
+    payload = bytearray(56)
+    payload[12:28] = b"SERIAL-RENOGY-01"
+    payload[36:52] = b"House Battery 1 "
+    payload[52:56] = b"1.02"
+    frame = _battery_frame(0x30, bytes(payload))
+
+    parsed = parse_battery_device_info(frame, variant=BATTERY_VARIANT_LEGACY)
+
+    assert parsed["battery_variant"] == BATTERY_VARIANT_LEGACY
+    assert parsed["serial_number"] == "SERIAL-RENOGY-01"
+    assert parsed["device_name"] == "House Battery 1"
+    assert parsed["sw_version"] == "1.02"
+
+
+def test_parse_battery_pack_status_variants() -> None:
+    """Legacy and Pro batteries should use their respective current scaling."""
+    payload = bytearray(14)
+    payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+    payload[2:4] = (512).to_bytes(2, "big")
+    payload[4:8] = (50000).to_bytes(4, "big")
+    payload[8:12] = (100000).to_bytes(4, "big")
+    payload[12:14] = (42).to_bytes(2, "big")
+
+    legacy_frame = _battery_frame(0x30, bytes(payload))
+    pro_frame = _battery_frame(0xFF, bytes(payload))
+
+    legacy = parse_battery_pack_status(legacy_frame, variant=BATTERY_VARIANT_LEGACY)
+    pro = parse_battery_pack_status(pro_frame, variant=BATTERY_VARIANT_PRO)
+
+    assert legacy["battery_voltage"] == 51.2
+    assert legacy["battery_current"] == 12.34
+    assert legacy["battery_percentage"] == 50.0
+    assert legacy["battery_cycle_count"] == 42
+    assert pro["battery_current"] == 123.4
+
+
+def test_parse_battery_cell_status_and_faults() -> None:
+    """Cell and fault parsing should expose derived metrics."""
+    payload = bytearray(68)
+    payload[0:2] = (4).to_bytes(2, "big")
+    for index, value in enumerate((330, 329, 331, 332)):
+        start = 2 + index * 2
+        payload[start : start + 2] = value.to_bytes(2, "big")
+    payload[34:36] = (2).to_bytes(2, "big")
+    payload[36:38] = (215).to_bytes(2, "big", signed=True)
+    payload[38:40] = (225).to_bytes(2, "big", signed=True)
+
+    cell_frame = _battery_frame(0x30, bytes(payload))
+    parsed_cells = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_LEGACY)
+
+    assert parsed_cells["cell_count"] == 4
+    assert parsed_cells["cell_voltages"] == [33.0, 32.9, 33.1, 33.2]
+    assert parsed_cells["cell_voltage_min"] == 32.9
+    assert parsed_cells["cell_voltage_max"] == 33.2
+    assert parsed_cells["cell_voltage_delta"] == 0.3
+    assert parsed_cells["battery_temperature"] == 22.0
+
+    fault_payload = bytearray(16)
+    fault_payload[13] = 0x16
+    fault_payload[14] = 0x20
+    fault_frame = _battery_frame(0x30, bytes(fault_payload))
+    parsed_faults = parse_battery_mosfet_status(
+        fault_frame, variant=BATTERY_VARIANT_LEGACY
+    )
+
+    assert parsed_faults["battery_problem_code"] > 0
+    assert parsed_faults["charge_mosfet_enabled"] is True
+    assert parsed_faults["discharge_mosfet_enabled"] is True
+    assert parsed_faults["heater_enabled"] is True

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -99,7 +99,7 @@ def test_parse_battery_cell_status_and_faults() -> None:
     """Cell and fault parsing should expose derived metrics."""
     payload = bytearray(68)
     payload[0:2] = (4).to_bytes(2, "big")
-    for index, value in enumerate((330, 329, 331, 332)):
+    for index, value in enumerate((3300, 3290, 3310, 3320)):
         start = 2 + index * 2
         payload[start : start + 2] = value.to_bytes(2, "big")
     payload[34:36] = (2).to_bytes(2, "big")
@@ -110,10 +110,10 @@ def test_parse_battery_cell_status_and_faults() -> None:
     parsed_cells = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_LEGACY)
 
     assert parsed_cells["cell_count"] == 4
-    assert parsed_cells["cell_voltages"] == [33.0, 32.9, 33.1, 33.2]
-    assert parsed_cells["cell_voltage_min"] == 32.9
-    assert parsed_cells["cell_voltage_max"] == 33.2
-    assert parsed_cells["cell_voltage_delta"] == 0.3
+    assert parsed_cells["cell_voltages"] == [3.3, 3.29, 3.31, 3.32]
+    assert parsed_cells["cell_voltage_min"] == 3.29
+    assert parsed_cells["cell_voltage_max"] == 3.32
+    assert parsed_cells["cell_voltage_delta"] == 0.03
     assert parsed_cells["battery_temperature"] == 22.0
 
     fault_payload = bytearray(16)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -95,6 +95,24 @@ def test_parse_battery_pack_status_variants() -> None:
     assert pro["battery_current"] == 123.4
 
 
+def test_parse_battery_pack_status_preserves_fractional_capacity() -> None:
+    """Battery pack status should preserve fractional amp-hour capacities."""
+    payload = bytearray(14)
+    payload[0:2] = int(250).to_bytes(2, "big", signed=True)
+    payload[2:4] = (512).to_bytes(2, "big")
+    payload[4:8] = (50000).to_bytes(4, "big")
+    payload[8:12] = (99500).to_bytes(4, "big")
+    payload[12:14] = (42).to_bytes(2, "big")
+
+    frame = _battery_frame(0x30, bytes(payload))
+
+    parsed = parse_battery_pack_status(frame, variant=BATTERY_VARIANT_LEGACY)
+
+    assert parsed["battery_remaining_capacity"] == 50.0
+    assert parsed["battery_capacity"] == 99.5
+    assert parsed["battery_percentage"] == 50.3
+
+
 def test_parse_battery_cell_status_and_faults() -> None:
     """Cell and fault parsing should expose derived metrics."""
     payload = bytearray(68)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -5,6 +5,7 @@ from renogy_ble.battery import (
     BATTERY_VARIANT_PRO,
     build_battery_command,
     detect_battery_variant,
+    is_supported_battery_name,
     parse_battery_cell_status,
     parse_battery_device_info,
     parse_battery_mosfet_status,
@@ -29,12 +30,22 @@ def test_detect_battery_variant_from_name_and_manufacturer_data() -> None:
     """Battery detection should distinguish Pro and legacy families."""
     assert detect_battery_variant("RNGRBP123456") == BATTERY_VARIANT_PRO
     assert detect_battery_variant("RNGC123456") == BATTERY_VARIANT_PRO
-    assert detect_battery_variant("BT-TH-123456") == BATTERY_VARIANT_LEGACY
+    assert detect_battery_variant("BT-TH-BATT01") == BATTERY_VARIANT_LEGACY
+    assert detect_battery_variant("BT-TH-123456") is None
     assert (
         detect_battery_variant("Unknown", manufacturer_data={0xE14C: b"\x01"})
         == BATTERY_VARIANT_PRO
     )
     assert detect_battery_variant("Other") is None
+
+
+def test_is_supported_battery_name_accepts_manufacturer_data() -> None:
+    """The public battery helper should match the read-path detection inputs."""
+    assert is_supported_battery_name("BT-BATTERY") is False
+    assert (
+        is_supported_battery_name("BT-BATTERY", manufacturer_data={0xE14C: b"\x01"})
+        is True
+    )
 
 
 def test_build_battery_command_uses_variant_device_id() -> None:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -531,6 +531,94 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
+def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+
+            def _frame(device_id: int, payload_bytes: bytes) -> bytes:
+                frame = bytearray([device_id, 0x03, len(payload_bytes)])
+                frame.extend(payload_bytes)
+                crc_low, crc_high = modbus_crc(frame)
+                frame.extend([crc_low, crc_high])
+                return bytes(frame)
+
+            info_payload = bytearray(56)
+            info_payload[12:28] = b"RENOGY-PRO-0002 "
+            info_payload[36:52] = b"Pro Battery     "
+            info_payload[52:56] = b"2.10"
+
+            pack_payload = bytearray(14)
+            pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+            pack_payload[2:4] = (512).to_bytes(2, "big")
+            pack_payload[4:8] = (65000).to_bytes(4, "big")
+            pack_payload[8:12] = (100000).to_bytes(4, "big")
+            pack_payload[12:14] = (7).to_bytes(2, "big")
+
+            cell_payload = bytearray(68)
+            cell_payload[0:2] = (4).to_bytes(2, "big")
+            for index, value in enumerate((330, 330, 331, 331)):
+                start = 2 + index * 2
+                cell_payload[start : start + 2] = value.to_bytes(2, "big")
+            cell_payload[34:36] = (1).to_bytes(2, "big")
+            cell_payload[36:38] = (230).to_bytes(2, "big", signed=True)
+
+            mosfet_payload = bytearray(16)
+            mosfet_payload[13] = 0x02
+
+            responses = {
+                0x13F0: _frame(0xFF, bytes(info_payload)),
+                0x13B2: _frame(0xFF, bytes(pack_payload)),
+                0x1388: _frame(0xFF, bytes(cell_payload)),
+                0x13EC: _frame(0xFF, bytes(mosfet_payload)),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-BATTERY"),
+        device_type="battery",
+        manufacturer_data={0xE14C: b"\x01"},
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
+
+
 def test_read_device_battery_continues_after_command_timeout(monkeypatch):
     class DummyClient:
         def __init__(self):
@@ -625,6 +713,126 @@ def test_read_device_battery_continues_after_command_timeout(monkeypatch):
     assert len(dummy_client.writes) == 4
     assert dummy_client.stop_notify_calls == 1
     assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_battery_drops_stale_partial_poll_data(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.start_notify_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self.start_notify_calls += 1
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            self.writes.append(bytes(payload))
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    def _battery_frame(device_id: int, payload_bytes: bytes) -> bytes:
+        frame = bytearray([device_id, 0x03, len(payload_bytes)])
+        frame.extend(payload_bytes)
+        crc_low, crc_high = modbus_crc(frame)
+        frame.extend([crc_low, crc_high])
+        return bytes(frame)
+
+    info_payload = bytearray(56)
+    info_payload[12:28] = b"RENOGY-BAT-0001 "
+    info_payload[36:52] = b"House Battery 1 "
+    info_payload[52:56] = b"1.02"
+
+    pack_payload = bytearray(14)
+    pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+    pack_payload[2:4] = (512).to_bytes(2, "big")
+    pack_payload[4:8] = (50000).to_bytes(4, "big")
+    pack_payload[8:12] = (100000).to_bytes(4, "big")
+    pack_payload[12:14] = (42).to_bytes(2, "big")
+
+    cell_payload = bytearray(68)
+    cell_payload[0:2] = (4).to_bytes(2, "big")
+    for index, value in enumerate((330, 329, 331, 332)):
+        start = 2 + index * 2
+        cell_payload[start : start + 2] = value.to_bytes(2, "big")
+    cell_payload[34:36] = (2).to_bytes(2, "big")
+    cell_payload[36:38] = (215).to_bytes(2, "big", signed=True)
+    cell_payload[38:40] = (225).to_bytes(2, "big", signed=True)
+
+    mosfet_payload = bytearray(16)
+    mosfet_payload[13] = 0x16
+    mosfet_payload[14] = 0x20
+
+    responses = {
+        "battery device_info": _battery_frame(0x30, bytes(info_payload)),
+        "battery pack_status": _battery_frame(0x30, bytes(pack_payload)),
+        "battery cell_status": _battery_frame(0x30, bytes(cell_payload)),
+        "battery mosfet_status": _battery_frame(0x30, bytes(mosfet_payload)),
+    }
+
+    dummy_client = DummyClient()
+    poll_number = 0
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    async def _fake_wait_for_valid_read_response(
+        _session,
+        *,
+        cmd_name,
+        **_kwargs,
+    ):
+        if poll_number == 1 and cmd_name in {
+            "battery cell_status",
+            "battery mosfet_status",
+        }:
+            raise asyncio.TimeoutError()
+
+        return responses[cmd_name]
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(transport_mode="persistent_session")
+    monkeypatch.setattr(
+        client,
+        "_wait_for_valid_read_response",
+        _fake_wait_for_valid_read_response,
+    )
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-TH-BATT01"), device_type="battery"
+    )
+
+    async def _run() -> tuple[dict[str, object], dict[str, object]]:
+        nonlocal poll_number
+        first = await client.read_device(device)
+        poll_number = 1
+        second = await client.read_device(device)
+        await client.close_device(device)
+        return first.parsed_data, second.parsed_data
+
+    first_data, second_data = asyncio.run(_run())
+
+    assert first_data["battery_temperature"] == 22.0
+    assert first_data["charge_mosfet_enabled"] is True
+    assert second_data["battery_voltage"] == 51.2
+    assert second_data["battery_current"] == 12.34
+    assert second_data["serial_number"] == "RENOGY-BAT-0001"
+    assert second_data["sw_version"] == "1.02"
+    assert "battery_temperature" not in second_data
+    assert "cell_count" not in second_data
+    assert "charge_mosfet_enabled" not in second_data
+    assert "discharge_mosfet_enabled" not in second_data
+    assert "heater_enabled" not in second_data
 
 
 def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -835,6 +835,52 @@ def test_read_device_battery_drops_stale_partial_poll_data(monkeypatch):
     assert "heater_enabled" not in second_data
 
 
+def test_read_device_battery_clears_stale_telemetry_after_reconnect_failure(
+    monkeypatch,
+):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = False
+            self.disconnect_calls = 0
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-TH-BATT01"), device_type="battery"
+    )
+    device.parsed_data = {
+        "serial_number": "RENOGY-BAT-0001",
+        "sw_version": "1.02",
+        "battery_variant": BATTERY_VARIANT_LEGACY,
+        "model": "Renogy Bluetooth Battery",
+        "battery_voltage": 51.2,
+        "battery_current": 12.34,
+    }
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is False
+    assert result.error is not None
+    assert result.parsed_data == {
+        "serial_number": "RENOGY-BAT-0001",
+        "sw_version": "1.02",
+        "battery_variant": BATTERY_VARIANT_LEGACY,
+        "model": "Renogy Bluetooth Battery",
+    }
+    assert device.parsed_data == result.parsed_data
+
+
 def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(
     monkeypatch,
 ):

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -531,6 +531,102 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
+def test_read_device_battery_continues_after_command_timeout(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            self.writes.append(bytes(payload))
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    def _battery_frame(device_id: int, payload_bytes: bytes) -> bytes:
+        frame = bytearray([device_id, 0x03, len(payload_bytes)])
+        frame.extend(payload_bytes)
+        crc_low, crc_high = modbus_crc(frame)
+        frame.extend([crc_low, crc_high])
+        return bytes(frame)
+
+    info_payload = bytearray(56)
+    info_payload[12:28] = b"RENOGY-BAT-0001 "
+    info_payload[36:52] = b"House Battery 1 "
+    info_payload[52:56] = b"1.02"
+
+    pack_payload = bytearray(14)
+    pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+    pack_payload[2:4] = (512).to_bytes(2, "big")
+    pack_payload[4:8] = (50000).to_bytes(4, "big")
+    pack_payload[8:12] = (100000).to_bytes(4, "big")
+    pack_payload[12:14] = (42).to_bytes(2, "big")
+
+    mosfet_payload = bytearray(16)
+    mosfet_payload[13] = 0x16
+    mosfet_payload[14] = 0x20
+
+    responses = {
+        "battery device_info": _battery_frame(0x30, bytes(info_payload)),
+        "battery pack_status": _battery_frame(0x30, bytes(pack_payload)),
+        "battery mosfet_status": _battery_frame(0x30, bytes(mosfet_payload)),
+    }
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    async def _fake_wait_for_valid_read_response(
+        _session,
+        *,
+        cmd_name,
+        **_kwargs,
+    ):
+        if cmd_name == "battery cell_status":
+            raise asyncio.TimeoutError()
+
+        return responses[cmd_name]
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    monkeypatch.setattr(
+        client,
+        "_wait_for_valid_read_response",
+        _fake_wait_for_valid_read_response,
+    )
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-TH-BATT01"), device_type="battery"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.error is None
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_LEGACY
+    assert result.parsed_data["battery_voltage"] == 51.2
+    assert result.parsed_data["battery_current"] == 12.34
+    assert result.parsed_data["charge_mosfet_enabled"] is True
+    assert "battery_temperature" not in result.parsed_data
+    assert device.name == "House Battery 1"
+    assert len(dummy_client.writes) == 4
+    assert dummy_client.stop_notify_calls == 1
+    assert dummy_client.disconnect_calls == 1
+
+
 def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(
     monkeypatch,
 ):

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Callable
 from unittest.mock import MagicMock
 
+from renogy_ble.battery import BATTERY_VARIANT_LEGACY, BATTERY_VARIANT_PRO
 from renogy_ble.ble import (
     DEFAULT_DEVICE_ID,
     INVERTER_DEVICE_ID,
@@ -337,6 +338,197 @@ def test_read_device_reads_inverter_data_with_validated_frames(monkeypatch):
     assert [request[0] for request in dummy_client.writes] == [INVERTER_DEVICE_ID] * 4
     assert dummy_client.stop_notify_calls == 1
     assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_reads_legacy_battery_data(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+
+            def _frame(device_id: int, payload_bytes: bytes) -> bytes:
+                frame = bytearray([device_id, 0x03, len(payload_bytes)])
+                frame.extend(payload_bytes)
+                crc_low, crc_high = modbus_crc(frame)
+                frame.extend([crc_low, crc_high])
+                return bytes(frame)
+
+            info_payload = bytearray(56)
+            info_payload[12:28] = b"RENOGY-BAT-0001 "
+            info_payload[36:52] = b"House Battery 1 "
+            info_payload[52:56] = b"1.02"
+
+            pack_payload = bytearray(14)
+            pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+            pack_payload[2:4] = (512).to_bytes(2, "big")
+            pack_payload[4:8] = (50000).to_bytes(4, "big")
+            pack_payload[8:12] = (100000).to_bytes(4, "big")
+            pack_payload[12:14] = (42).to_bytes(2, "big")
+
+            cell_payload = bytearray(68)
+            cell_payload[0:2] = (4).to_bytes(2, "big")
+            for index, value in enumerate((330, 329, 331, 332)):
+                start = 2 + index * 2
+                cell_payload[start : start + 2] = value.to_bytes(2, "big")
+            cell_payload[34:36] = (2).to_bytes(2, "big")
+            cell_payload[36:38] = (215).to_bytes(2, "big", signed=True)
+            cell_payload[38:40] = (225).to_bytes(2, "big", signed=True)
+
+            mosfet_payload = bytearray(16)
+            mosfet_payload[13] = 0x16
+            mosfet_payload[14] = 0x20
+
+            responses = {
+                0x13F0: _frame(0x30, bytes(info_payload)),
+                0x13B2: _frame(0x30, bytes(pack_payload)),
+                0x1388: _frame(0x30, bytes(cell_payload)),
+                0x13EC: _frame(0x30, bytes(mosfet_payload)),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-TH-BATT01"), device_type="battery"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.error is None
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_LEGACY
+    assert result.parsed_data["battery_voltage"] == 51.2
+    assert result.parsed_data["battery_current"] == 12.34
+    assert result.parsed_data["battery_percentage"] == 50.0
+    assert result.parsed_data["battery_cycle_count"] == 42
+    assert result.parsed_data["cell_count"] == 4
+    assert result.parsed_data["battery_temperature"] == 22.0
+    assert result.parsed_data["charge_mosfet_enabled"] is True
+    assert result.parsed_data["discharge_mosfet_enabled"] is True
+    assert result.parsed_data["heater_enabled"] is True
+    assert device.name == "House Battery 1"
+    assert [request[0] for request in dummy_client.writes] == [0x30] * 4
+    assert dummy_client.stop_notify_calls == 1
+    assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_reads_battery_pro_data(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+
+            def _frame(device_id: int, payload_bytes: bytes) -> bytes:
+                frame = bytearray([device_id, 0x03, len(payload_bytes)])
+                frame.extend(payload_bytes)
+                crc_low, crc_high = modbus_crc(frame)
+                frame.extend([crc_low, crc_high])
+                return bytes(frame)
+
+            info_payload = bytearray(56)
+            info_payload[12:28] = b"RENOGY-PRO-0002 "
+            info_payload[36:52] = b"Pro Battery     "
+            info_payload[52:56] = b"2.10"
+
+            pack_payload = bytearray(14)
+            pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+            pack_payload[2:4] = (512).to_bytes(2, "big")
+            pack_payload[4:8] = (65000).to_bytes(4, "big")
+            pack_payload[8:12] = (100000).to_bytes(4, "big")
+            pack_payload[12:14] = (7).to_bytes(2, "big")
+
+            cell_payload = bytearray(68)
+            cell_payload[0:2] = (4).to_bytes(2, "big")
+            for index, value in enumerate((330, 330, 331, 331)):
+                start = 2 + index * 2
+                cell_payload[start : start + 2] = value.to_bytes(2, "big")
+            cell_payload[34:36] = (1).to_bytes(2, "big")
+            cell_payload[36:38] = (230).to_bytes(2, "big", signed=True)
+
+            mosfet_payload = bytearray(16)
+            mosfet_payload[13] = 0x02
+
+            responses = {
+                0x13F0: _frame(0xFF, bytes(info_payload)),
+                0x13B2: _frame(0xFF, bytes(pack_payload)),
+                0x1388: _frame(0xFF, bytes(cell_payload)),
+                0x13EC: _frame(0xFF, bytes(mosfet_payload)),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="RNGRBP123456"), device_type="battery"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert result.parsed_data["battery_current"] == 123.4
+    assert result.parsed_data["battery_percentage"] == 65.0
+    assert result.parsed_data["battery_cycle_count"] == 7
+    assert result.parsed_data["battery_temperature"] == 23.0
+    assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
 def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(


### PR DESCRIPTION
## What changed
- added native Renogy battery protocol support to `renogy-ble`
- implemented explicit legacy and Pro battery variant handling with a dedicated battery read path
- exposed parsed battery telemetry including pack values, cell metrics, temperatures, and fault/MOSFET state
- added fixture-based unit tests for battery protocol helpers and end-to-end battery reads

## Why
`renogy-ha` needed first-party Renogy battery support from the shared BLE library. The implementation stays inside `renogy-ble` so protocol detection, transport, and parsing remain independent of Home Assistant.

## Impact
Consumers of `renogy-ble` can now read supported Renogy battery variants through the library API using `device_type="battery"`.

## Validation
- `uv run ruff format .`
- `uv run ruff check . --output-format=github`
- `uv run ty check . --output-format=github`
- `uv run pytest tests`
