### PR TITLE
[codex] Fix Renogy battery polling for legacy and Pro devices

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -12,13 +12,16 @@ from typing import Any, Literal, Optional
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
+from bleak.uuids import normalize_uuid_str
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 
 from renogy_ble.battery import (
     BATTERY_COMMANDS,
     BATTERY_DEFAULT_MODELS,
     BATTERY_DEVICE_TYPE,
+    BATTERY_LEGACY_NAME_PREFIX,
     BATTERY_PROTOCOL_DEVICE_IDS,
+    BATTERY_VARIANT_LEGACY,
     BatteryVariant,
     build_battery_command,
     detect_battery_variant,
@@ -34,6 +37,8 @@ logger = logging.getLogger(__name__)
 # BLE Characteristics and Service UUIDs
 RENOGY_READ_CHAR_UUID = "0000fff1-0000-1000-8000-00805f9b34fb"
 RENOGY_WRITE_CHAR_UUID = "0000ffd1-0000-1000-8000-00805f9b34fb"
+RENOGY_NOTIFY_SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
+RENOGY_WRITE_SERVICE_UUID = "0000ffd0-0000-1000-8000-00805f9b34fb"
 
 # Time in minutes to wait before attempting to reconnect to unavailable devices
 UNAVAILABLE_RETRY_INTERVAL = 10
@@ -428,6 +433,8 @@ class _PersistentBleSession:
     notification_event: asyncio.Event = field(default_factory=asyncio.Event)
     notification_data: bytearray = field(default_factory=bytearray)
     notify_started: bool = False
+    read_target: int | str | None = None
+    write_target: int | str | None = None
 
 
 class RenogyBleClient:
@@ -611,6 +618,13 @@ class RenogyBleClient:
             device.name,
             manufacturer_data=device.manufacturer_data,
         )
+        if variant is None and device.name.startswith(BATTERY_LEGACY_NAME_PREFIX):
+            logger.debug(
+                "Falling back to legacy battery protocol for manually configured "
+                "BT-TH device %s",
+                device.name,
+            )
+            variant = BATTERY_VARIANT_LEGACY
         stable_data: dict[str, Any] = {
             key: cached_data[key]
             for key in ("serial_number", "device_name", "sw_version")
@@ -666,7 +680,10 @@ class RenogyBleClient:
                         raise RuntimeError("BLE session is not connected")
 
                     request = build_battery_command(variant, register, word_count)
-                    await session.client.write_gatt_char(self._write_char_uuid, request)
+                    await session.client.write_gatt_char(
+                        session.write_target or self._write_char_uuid,
+                        request,
+                    )
                     try:
                         result_data = await self._wait_for_valid_read_response(
                             session,
@@ -1013,6 +1030,7 @@ class RenogyBleClient:
                 return RenogyBleWriteResult(False, connection_error)
 
             self._reset_notifications(session)
+            write_target = session.write_target or self._write_char_uuid
             modbus_request = create_modbus_write_request(
                 self._device_id, register, value, function_code=function_code
             )
@@ -1024,7 +1042,7 @@ class RenogyBleClient:
                 if session.client is None:
                     raise RuntimeError("BLE session is not connected")
                 await session.client.write_gatt_char(
-                    self._write_char_uuid,
+                    write_target,
                     modbus_request,
                 )
                 await self._wait_for_write_response(
@@ -1164,6 +1182,10 @@ class RenogyBleClient:
             )
             session.notify_started = False
             self._reset_notifications(session)
+            session.read_target = self._read_char_uuid
+            session.write_target = self._write_char_uuid
+            if device.device_type == BATTERY_DEVICE_TYPE:
+                self._resolve_battery_characteristics(device, session)
 
         if session.notify_started:
             return
@@ -1172,8 +1194,62 @@ class RenogyBleClient:
             session.notification_data.extend(data)
             session.notification_event.set()
 
-        await session.client.start_notify(self._read_char_uuid, notification_handler)
+        await session.client.start_notify(
+            session.read_target or self._read_char_uuid, notification_handler
+        )
         session.notify_started = True
+
+    def _resolve_battery_characteristics(
+        self,
+        device: RenogyBLEDevice,
+        session: _PersistentBleSession,
+    ) -> None:
+        """Resolve Renogy battery characteristic handles from the expected services."""
+        if session.client is None:
+            raise RuntimeError("BLE session is not connected")
+
+        services = getattr(session.client, "services", None)
+        if services is None:
+            logger.debug(
+                "BLE services unavailable while resolving battery characteristics "
+                "for %s; falling back to UUID access",
+                device.name,
+            )
+            return
+
+        notify_handle = None
+        write_handle = None
+        notify_service_uuid = normalize_uuid_str(RENOGY_NOTIFY_SERVICE_UUID)
+        write_service_uuid = normalize_uuid_str(RENOGY_WRITE_SERVICE_UUID)
+        notify_char_uuid = normalize_uuid_str(self._read_char_uuid)
+        write_char_uuid = normalize_uuid_str(self._write_char_uuid)
+
+        for service in services:
+            service_uuid = normalize_uuid_str(service.uuid)
+            for characteristic in service.characteristics:
+                char_uuid = normalize_uuid_str(characteristic.uuid)
+                properties = set(characteristic.properties)
+                if (
+                    service_uuid == write_service_uuid
+                    and char_uuid == write_char_uuid
+                    and {"write", "write-without-response"} & properties
+                ):
+                    write_handle = characteristic.handle
+                if (
+                    service_uuid == notify_service_uuid
+                    and char_uuid == notify_char_uuid
+                    and "notify" in properties
+                ):
+                    notify_handle = characteristic.handle
+
+        if notify_handle is None or write_handle is None:
+            raise ConnectionError(
+                "Failed to resolve Renogy battery BLE characteristics for "
+                f"{device.name}."
+            )
+
+        session.read_target = notify_handle
+        session.write_target = write_handle
 
     async def _close_session(
         self,
@@ -1187,7 +1263,9 @@ class RenogyBleClient:
         if session.client is not None:
             if session.notify_started:
                 try:
-                    await session.client.stop_notify(self._read_char_uuid)
+                    await session.client.stop_notify(
+                        session.read_target or self._read_char_uuid
+                    )
                 except Exception as exc:
                     logger.debug(
                         "Error stopping notify for device %s: %s",
@@ -1208,6 +1286,8 @@ class RenogyBleClient:
 
         session.client = None
         session.notify_started = False
+        session.read_target = None
+        session.write_target = None
         self._reset_notifications(session)
 
         if remove:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -619,6 +619,220 @@ def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch)
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
+def test_read_device_falls_back_to_legacy_variant_for_manual_bt_th_battery(
+    monkeypatch,
+):
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.writes: list[bytes] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.writes.append(request)
+            register = int.from_bytes(request[2:4], "big")
+
+            def _frame(device_id: int, payload_bytes: bytes) -> bytes:
+                frame = bytearray([device_id, 0x03, len(payload_bytes)])
+                frame.extend(payload_bytes)
+                crc_low, crc_high = modbus_crc(frame)
+                frame.extend([crc_low, crc_high])
+                return bytes(frame)
+
+            info_payload = bytearray(56)
+            info_payload[12:28] = b"RENOGY-BAT-0001 "
+            info_payload[36:52] = b"House Battery 1 "
+            info_payload[52:56] = b"1.02"
+
+            pack_payload = bytearray(14)
+            pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+            pack_payload[2:4] = (512).to_bytes(2, "big")
+            pack_payload[4:8] = (50000).to_bytes(4, "big")
+            pack_payload[8:12] = (100000).to_bytes(4, "big")
+            pack_payload[12:14] = (42).to_bytes(2, "big")
+
+            cell_payload = bytearray(68)
+            cell_payload[0:2] = (4).to_bytes(2, "big")
+            for index, value in enumerate((330, 329, 331, 332)):
+                start = 2 + index * 2
+                cell_payload[start : start + 2] = value.to_bytes(2, "big")
+            cell_payload[34:36] = (2).to_bytes(2, "big")
+            cell_payload[36:38] = (215).to_bytes(2, "big", signed=True)
+            cell_payload[38:40] = (225).to_bytes(2, "big", signed=True)
+
+            mosfet_payload = bytearray(16)
+            mosfet_payload[13] = 0x16
+            mosfet_payload[14] = 0x20
+
+            responses = {
+                0x13F0: _frame(0x30, bytes(info_payload)),
+                0x13B2: _frame(0x30, bytes(pack_payload)),
+                0x1388: _frame(0x30, bytes(cell_payload)),
+                0x13EC: _frame(0x30, bytes(mosfet_payload)),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="BT-TH-123456"), device_type="battery"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_LEGACY
+    assert result.parsed_data["battery_voltage"] == 51.2
+    assert [request[0] for request in dummy_client.writes] == [0x30] * 4
+
+
+def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monkeypatch):
+    class DummyCharacteristic:
+        def __init__(self, uuid: str, handle: int, properties: list[str]):
+            self.uuid = uuid
+            self.handle = handle
+            self.properties = properties
+
+    class DummyService:
+        def __init__(self, uuid: str, characteristics: list[DummyCharacteristic]):
+            self.uuid = uuid
+            self.characteristics = characteristics
+
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.start_notify_targets: list[int | str] = []
+            self.write_targets: list[int | str] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+            self.services = [
+                DummyService(
+                    "0000ffd0-0000-1000-8000-00805f9b34fb",
+                    [
+                        DummyCharacteristic(
+                            "0000ffd1-0000-1000-8000-00805f9b34fb",
+                            17,
+                            ["write-without-response"],
+                        )
+                    ],
+                ),
+                DummyService(
+                    "0000fff0-0000-1000-8000-00805f9b34fb",
+                    [
+                        DummyCharacteristic(
+                            "0000fff1-0000-1000-8000-00805f9b34fb",
+                            33,
+                            ["notify"],
+                        )
+                    ],
+                ),
+            ]
+
+        async def start_notify(self, target, callback):
+            self.start_notify_targets.append(target)
+            self._notify_handler = callback
+
+        async def write_gatt_char(self, target, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            request = bytes(payload)
+            self.write_targets.append(target)
+            register = int.from_bytes(request[2:4], "big")
+
+            def _frame(device_id: int, payload_bytes: bytes) -> bytes:
+                frame = bytearray([device_id, 0x03, len(payload_bytes)])
+                frame.extend(payload_bytes)
+                crc_low, crc_high = modbus_crc(frame)
+                frame.extend([crc_low, crc_high])
+                return bytes(frame)
+
+            info_payload = bytearray(56)
+            info_payload[12:28] = b"RENOGY-PRO-0002 "
+            info_payload[36:52] = b"Pro Battery     "
+            info_payload[52:56] = b"2.10"
+
+            pack_payload = bytearray(14)
+            pack_payload[0:2] = int(1234).to_bytes(2, "big", signed=True)
+            pack_payload[2:4] = (512).to_bytes(2, "big")
+            pack_payload[4:8] = (65000).to_bytes(4, "big")
+            pack_payload[8:12] = (100000).to_bytes(4, "big")
+            pack_payload[12:14] = (7).to_bytes(2, "big")
+
+            cell_payload = bytearray(68)
+            cell_payload[0:2] = (4).to_bytes(2, "big")
+            for index, value in enumerate((330, 330, 331, 331)):
+                start = 2 + index * 2
+                cell_payload[start : start + 2] = value.to_bytes(2, "big")
+            cell_payload[34:36] = (1).to_bytes(2, "big")
+            cell_payload[36:38] = (230).to_bytes(2, "big", signed=True)
+
+            mosfet_payload = bytearray(16)
+            mosfet_payload[13] = 0x02
+
+            responses = {
+                0x13F0: _frame(0xFF, bytes(info_payload)),
+                0x13B2: _frame(0xFF, bytes(pack_payload)),
+                0x1388: _frame(0xFF, bytes(cell_payload)),
+                0x13EC: _frame(0xFF, bytes(mosfet_payload)),
+            }
+            self._notify_handler(None, responses[register])
+
+        async def stop_notify(self, target):
+            self.stop_notify_calls += 1
+            self.start_notify_targets.append(target)
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="RNGRBP123456"), device_type="battery"
+    )
+
+    result = asyncio.run(client.read_device(device))
+
+    assert result.success is True
+    assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert dummy_client.start_notify_targets[0] == 33
+    assert dummy_client.write_targets == [17] * 4
+
+
 def test_read_device_battery_continues_after_command_timeout(monkeypatch):
     class DummyClient:
         def __init__(self):


### PR DESCRIPTION
## Summary

Fix Renogy battery polling failures for two battery paths:

- fall back to the legacy battery protocol when a battery is manually configured from a generic `BT-TH-*` advertisement
- resolve the battery notify/write characteristic handles from the expected services before polling, matching the working Renogy battery transport pattern used by reference implementations

## Why

Users were reporting that Renogy battery entities were created but remained unavailable. There were two contributing issues:

- Older external BT module batteries can advertise as generic `BT-TH-*` names, which are ambiguous. When a user explicitly selected `battery`, the read path still failed because no battery protocol variant could be inferred and polling aborted before any commands were sent.
- Renogy Pro batteries may require service-specific characteristic handle resolution instead of direct UUID access, so the existing poll path could connect successfully but never receive valid updates.

## What changed

- Added a legacy protocol fallback for manually configured `BT-TH-*` battery devices.
- Added battery-specific characteristic resolution using the expected `FFF0/FFF1` notify path and `FFD0/FFD1` write path.
- Updated battery reads and writes to use resolved targets when available.
- Added regression tests covering:
  - manual `BT-TH-*` battery fallback to the legacy protocol
  - service/handle-based polling for Renogy Pro batteries

## Impact

- Older external-module batteries should now poll successfully after the user selects `battery` during setup.
- Pro batteries should be more robust when their BLE characteristics are exposed in a way that requires handle resolution.
- Home Assistant integrations consuming `renogy-ble` should receive fresh battery telemetry instead of persistent `Unavailable` entities in these cases.

## Validation

- `uv run ruff format .`
- `uv run ruff check . --output-format=github`
- `uv run ty check . --output-format=github`
- `uv run pytest tests`
