### PR TITLE
Support RNGPRO-family batteries (e.g. RBT12500LFP-SHBT)

### DIFF
--- a/src/renogy_ble/__init__.py
+++ b/src/renogy_ble/__init__.py
@@ -11,6 +11,7 @@ from renogy_ble.battery import (
     BATTERY_DEVICE_TYPE,
     BATTERY_VARIANT_LEGACY,
     BATTERY_VARIANT_PRO,
+    BATTERY_VARIANT_RNGPRO,
     detect_battery_variant,
     is_supported_battery_name,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "BATTERY_DEVICE_TYPE",
     "BATTERY_VARIANT_LEGACY",
     "BATTERY_VARIANT_PRO",
+    "BATTERY_VARIANT_RNGPRO",
     "DEFAULT_DEVICE_ID",
     "DEFAULT_DEVICE_TYPE",
     "LOAD_CONTROL_REGISTER",

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -8,9 +8,14 @@ from typing import Any, Literal
 BATTERY_DEVICE_TYPE = "battery"
 BATTERY_VARIANT_LEGACY = "legacy"
 BATTERY_VARIANT_PRO = "pro"
-BatteryVariant = Literal["legacy", "pro"]
+# RNGPRO-family batteries (e.g. RBT12500LFP-SHBT) share the Pro register map and
+# device id but use different field scaling than RNGRBP/RNGC "pro" batteries:
+# current in 0.01 A units (not 0.1 A) and cell voltages in 0.1 V units (not mV).
+BATTERY_VARIANT_RNGPRO = "rngpro"
+BatteryVariant = Literal["legacy", "pro", "rngpro"]
 
 BATTERY_PRO_NAME_PREFIXES = ("RNGRBP", "RNGC")
+BATTERY_RNGPRO_NAME_PREFIXES = ("RNGPRO",)
 BATTERY_LEGACY_NAME_PREFIX = "BT-TH-"
 BATTERY_LEGACY_NAME_MARKERS = ("BATT", "BATTERY")
 BATTERY_PRO_MANUFACTURER_ID = 0xE14C
@@ -18,11 +23,13 @@ BATTERY_PRO_MANUFACTURER_ID = 0xE14C
 BATTERY_PROTOCOL_DEVICE_IDS: dict[BatteryVariant, int] = {
     BATTERY_VARIANT_LEGACY: 0x30,
     BATTERY_VARIANT_PRO: 0xFF,
+    BATTERY_VARIANT_RNGPRO: 0xFF,
 }
 
 BATTERY_DEFAULT_MODELS: dict[BatteryVariant, str] = {
     BATTERY_VARIANT_LEGACY: "Renogy Bluetooth Battery",
     BATTERY_VARIANT_PRO: "Renogy BT Battery Pro",
+    BATTERY_VARIANT_RNGPRO: "Renogy BT Battery Pro",
 }
 
 # Format: (register, word_count)
@@ -47,6 +54,9 @@ def detect_battery_variant(
     """Return the supported battery protocol variant for the given advertisement."""
     cleaned_name = (name or "").strip()
     manufacturer_data = manufacturer_data or {}
+
+    if cleaned_name.startswith(BATTERY_RNGPRO_NAME_PREFIXES):
+        return BATTERY_VARIANT_RNGPRO
 
     if cleaned_name.startswith(BATTERY_PRO_NAME_PREFIXES):
         return BATTERY_VARIANT_PRO
@@ -176,15 +186,16 @@ def parse_battery_cell_status(
     variant: BatteryVariant,
 ) -> dict[str, Any]:
     """Parse cell voltages and temperature sensors."""
-    _ = variant
     parsed: dict[str, Any] = {}
 
     cell_count = int.from_bytes(data[3:5], byteorder="big")
     parsed["cell_count"] = cell_count
 
-    # Cell voltage registers are reported in millivolts.
+    # Cell voltage units differ by protocol variant: legacy/pro report
+    # millivolts, while RNGPRO-family batteries report 0.1 V units.
+    cell_divisor = 10 if variant == BATTERY_VARIANT_RNGPRO else 1000
     cell_values = [
-        int.from_bytes(data[start : start + 2], byteorder="big") / 1000
+        int.from_bytes(data[start : start + 2], byteorder="big") / cell_divisor
         for start in range(5, 5 + min(cell_count, 16) * 2, 2)
     ]
     if cell_values:
@@ -215,8 +226,15 @@ def parse_battery_mosfet_status(
     variant: BatteryVariant,
 ) -> dict[str, Any]:
     """Parse fault and MOSFET flags."""
-    _ = variant
-    problem_code = int.from_bytes(data[3:17], byteorder="big") & (~0xE)
+    if variant == BATTERY_VARIANT_RNGPRO:
+        # RNGPRO-family batteries do not expose the fault bitmask across the same
+        # 14-byte span; the generic decode picks up non-fault status bytes (e.g.
+        # 0xAA) and yields a spurious, permanently-nonzero value. Until the
+        # RNGPRO fault-register layout is characterized, report no fault rather
+        # than a false positive. The MOSFET flags below decode correctly.
+        problem_code = 0
+    else:
+        problem_code = int.from_bytes(data[3:17], byteorder="big") & (~0xE)
 
     return {
         "battery_problem_code": problem_code,

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -226,19 +226,20 @@ def parse_battery_mosfet_status(
     variant: BatteryVariant,
 ) -> dict[str, Any]:
     """Parse fault and MOSFET flags."""
-    if variant == BATTERY_VARIANT_RNGPRO:
-        # RNGPRO-family batteries do not expose the fault bitmask across the same
-        # 14-byte span; the generic decode picks up non-fault status bytes (e.g.
-        # 0xAA) and yields a spurious, permanently-nonzero value. Until the
-        # RNGPRO fault-register layout is characterized, report no fault rather
-        # than a false positive. The MOSFET flags below decode correctly.
-        problem_code = 0
-    else:
-        problem_code = int.from_bytes(data[3:17], byteorder="big") & (~0xE)
-
-    return {
-        "battery_problem_code": problem_code,
+    parsed: dict[str, Any] = {
         "charge_mosfet_enabled": bool(data[16] & 0x2),
         "discharge_mosfet_enabled": bool(data[16] & 0x4),
         "heater_enabled": bool(data[17] & 0x20),
     }
+
+    # RNGPRO-family batteries do not expose the fault bitmask across the same
+    # 14-byte span; the generic decode picks up non-fault status bytes (e.g.
+    # 0xAA) and yields a spurious, permanently-nonzero value. Until the RNGPRO
+    # fault-register layout is characterized, omit the problem code so consumers
+    # represent it as unknown rather than falsely reporting no fault.
+    if variant != BATTERY_VARIANT_RNGPRO:
+        parsed["battery_problem_code"] = int.from_bytes(data[3:17], byteorder="big") & (
+            ~0xE
+        )
+
+    return parsed

--- a/tests/test_battery_rngpro.py
+++ b/tests/test_battery_rngpro.py
@@ -6,6 +6,7 @@ RBT12500LFP-SHBT (12 V / 500 Ah) battery, which advertises as
 own readout: 13.3 V, ~2 A discharge, 3.3 V/cell, ~23 C, 500 Ah.
 """
 
+import renogy_ble
 from renogy_ble.battery import (
     BATTERY_VARIANT_PRO,
     BATTERY_VARIANT_RNGPRO,
@@ -30,6 +31,11 @@ def test_detect_rngpro_variant() -> None:
     assert is_supported_battery_name("RNGPRO125BAT-EF036881") is True
     # existing RNGRBP/RNGC batteries must remain classified as plain "pro"
     assert detect_battery_variant("RNGRBP123456") == BATTERY_VARIANT_PRO
+
+
+def test_rngpro_variant_is_exported_from_package() -> None:
+    assert renogy_ble.BATTERY_VARIANT_RNGPRO == BATTERY_VARIANT_RNGPRO
+    assert "BATTERY_VARIANT_RNGPRO" in renogy_ble.__all__
 
 
 def test_rngpro_uses_universal_device_id() -> None:
@@ -61,8 +67,13 @@ def test_rngpro_cell_status_scaling() -> None:
 
 def test_rngpro_mosfet_status_no_false_fault() -> None:
     parsed = parse_battery_mosfet_status(MOSFET_STATUS, variant=BATTERY_VARIANT_RNGPRO)
-    # the generic 14-byte fault span would yield a spurious huge value here
-    assert parsed["battery_problem_code"] == 0
+    # The generic 14-byte fault span would yield a spurious huge value here.
+    assert "battery_problem_code" not in parsed
     assert parsed["charge_mosfet_enabled"] is True
     assert parsed["discharge_mosfet_enabled"] is True
     assert parsed["heater_enabled"] is False
+
+
+def test_existing_pro_mosfet_status_keeps_fault_decoder() -> None:
+    parsed = parse_battery_mosfet_status(MOSFET_STATUS, variant=BATTERY_VARIANT_PRO)
+    assert parsed["battery_problem_code"] > 0

--- a/tests/test_battery_rngpro.py
+++ b/tests/test_battery_rngpro.py
@@ -1,0 +1,68 @@
+"""Regression tests for RNGPRO-family batteries (e.g. RBT12500LFP-SHBT).
+
+Frames below are raw Modbus responses captured over BLE from a real Renogy
+RBT12500LFP-SHBT (12 V / 500 Ah) battery, which advertises as
+``RNGPRO125BAT-*``. Ground-truth values were confirmed against the battery's
+own readout: 13.3 V, ~2 A discharge, 3.3 V/cell, ~23 C, 500 Ah.
+"""
+
+from renogy_ble.battery import (
+    BATTERY_VARIANT_PRO,
+    BATTERY_VARIANT_RNGPRO,
+    build_battery_command,
+    detect_battery_variant,
+    is_supported_battery_name,
+    parse_battery_cell_status,
+    parse_battery_mosfet_status,
+    parse_battery_pack_status,
+)
+
+# Raw response frames captured from the battery (full frames incl. id/func/len/CRC).
+PACK_STATUS = bytes.fromhex("ff030eff370085000746ee0007a1200018f9db")
+CELL_STATUS = bytes.fromhex(
+    "ff034400040021002100210021000000000000000000000000000000000000000000000000000300e900e300e200000000000000000000000000000000000000000000000000001917"
+)
+MOSFET_STATUS = bytes.fromhex("ff0310000000aa000000000000000000060000850f")
+
+
+def test_detect_rngpro_variant() -> None:
+    assert detect_battery_variant("RNGPRO125BAT-EF036881") == BATTERY_VARIANT_RNGPRO
+    assert is_supported_battery_name("RNGPRO125BAT-EF036881") is True
+    # existing RNGRBP/RNGC batteries must remain classified as plain "pro"
+    assert detect_battery_variant("RNGRBP123456") == BATTERY_VARIANT_PRO
+
+
+def test_rngpro_uses_universal_device_id() -> None:
+    frame = build_battery_command(BATTERY_VARIANT_RNGPRO, 0x13B2, 0x0007)
+    assert frame[:6] == bytes([0xFF, 0x03, 0x13, 0xB2, 0x00, 0x07])
+
+
+def test_rngpro_pack_status_scaling() -> None:
+    parsed = parse_battery_pack_status(PACK_STATUS, variant=BATTERY_VARIANT_RNGPRO)
+    assert parsed["battery_voltage"] == 13.3
+    # current is 0.01 A units for RNGPRO: 0xFF37 -> -201 -> -2.01 A (not -20.1)
+    assert parsed["battery_current"] == -2.01
+    assert parsed["battery_power"] == round(13.3 * -2.01, 3)
+    assert parsed["battery_capacity"] == 500.0
+    assert parsed["battery_remaining_capacity"] == 476.91
+    assert parsed["battery_percentage"] == 95.4
+    assert parsed["battery_cycle_count"] == 24
+
+
+def test_rngpro_cell_status_scaling() -> None:
+    parsed = parse_battery_cell_status(CELL_STATUS, variant=BATTERY_VARIANT_RNGPRO)
+    assert parsed["cell_count"] == 4
+    # cell voltages are 0.1 V units for RNGPRO: 0x0021 -> 33 -> 3.3 V (not 0.033)
+    assert parsed["cell_voltages"] == [3.3, 3.3, 3.3, 3.3]
+    assert parsed["battery_temperature_sensors"] == 3
+    assert parsed["battery_temperature_values"] == [23.3, 22.7, 22.6]
+    assert parsed["battery_temperature"] == 22.9
+
+
+def test_rngpro_mosfet_status_no_false_fault() -> None:
+    parsed = parse_battery_mosfet_status(MOSFET_STATUS, variant=BATTERY_VARIANT_RNGPRO)
+    # the generic 14-byte fault span would yield a spurious huge value here
+    assert parsed["battery_problem_code"] == 0
+    assert parsed["charge_mosfet_enabled"] is True
+    assert parsed["discharge_mosfet_enabled"] is True
+    assert parsed["heater_enabled"] is False


### PR DESCRIPTION
## Summary

Renogy's newer RNGPRO-family batteries — e.g. **RBT12500LFP-SHBT**, which advertises as `RNGPRO125BAT-*` — are not detected today. Their advertised name matches neither `BATTERY_PRO_NAME_PREFIXES` (`RNGRBP`/`RNGC`) nor the `0xE14C` manufacturer-ID fallback (these units carry only their MAC as manufacturer data), so `detect_battery_variant()` returns `None` and no data is read.

These batteries share the existing Pro register map and universal device id (`0xFF`), but use **different field scaling** than the RNGRBP/RNGC "pro" batteries the current parser was tuned for:

| Field | `pro` (RNGRBP/RNGC) | `rngpro` (this PR) |
|---|---|---|
| current | 0.1 A units (÷10) | **0.01 A units (÷100)** |
| cell voltage | millivolts (÷1000) | **0.1 V units (÷10)** |
| problem_code | 14-byte fault span | span reads non-fault status bytes → spurious value |

This PR adds a dedicated `rngpro` `BatteryVariant` so these batteries are detected and scaled correctly. The `legacy` and `pro` paths are unchanged — `pack_status` already routed non-`pro` variants through the ÷100 current scale, so only cell-voltage and problem-code needed variant branches.

## `problem_code`

On these batteries the generic 14-byte fault span (`data[3:17]`) picks up a non-fault status byte (`0xAA`) and yields a permanently-nonzero value. Until the RNGPRO fault-register layout is characterized, this PR reports `problem_code = 0` for the `rngpro` variant to avoid a false-positive fault. The MOSFET/heater flags decode correctly and are unchanged. Happy to follow up if anyone can capture a frame with an active fault.

## Testing

I personally tested this against my own hardware:

- **Battery:** Renogy **RBT12500LFP-SHBT** (12 V / 500 Ah), advertising as `RNGPRO125BAT-*`
- **DC-DC charger:** Renogy **DCC50S**

Parser output was verified against the battery's own readout across voltage, current, cell voltages, temperatures and SoC (e.g. current reads 1.67 A when the battery reports 1.67 A, i.e. raw 167 ÷ 100 — not 16.7 A). The added tests in `tests/test_battery_rngpro.py` assert these using **raw Modbus frames captured over BLE from the battery**.

I only own this one battery and a DCC50S, so **I cannot test for regressions on other Renogy devices** (other batteries, charge controllers, inverters, shunts). The change is scoped to a new variant that only activates for `RNGPRO*` advertisements, and the full existing test suite still passes.

`uv run pytest tests`, `uv run ruff check .`, and `uv run ty check .` pass locally.
