### PR TITLE
fix: read RNGRBP batteries and scale pro cell voltage as 0.1 V (follow-on to #120)

### DIFF
--- a/docs/batteries.md
+++ b/docs/batteries.md
@@ -36,6 +36,7 @@ async def main() -> None:
         ble_device,
         device_type="battery",
         manufacturer_data=advertisement.manufacturer_data,
+        advertisement_name=advertisement.local_name,
     )
     result = await RenogyBleClient().read_device(renogy_device)
     if result.success:

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -191,9 +191,14 @@ def parse_battery_cell_status(
     cell_count = int.from_bytes(data[3:5], byteorder="big")
     parsed["cell_count"] = cell_count
 
-    # Cell voltage units differ by protocol variant: legacy/pro report
-    # millivolts, while RNGPRO-family batteries report 0.1 V units.
-    cell_divisor = 10 if variant == BATTERY_VARIANT_RNGPRO else 1000
+    # Cell voltage units differ by protocol variant: legacy reports millivolts,
+    # while the pro (RNGRBP/RNGC) and RNGPRO families report 0.1 V units. #120
+    # corrected the RNGPRO variant; the pro family scales the same way, confirmed
+    # on RNGRBP hardware (4 cells x 3.6 V = 14.4 V pack, matching the pack-voltage
+    # register read separately) and cyrils/renogy-bt.
+    cell_divisor = (
+        10 if variant in (BATTERY_VARIANT_RNGPRO, BATTERY_VARIANT_PRO) else 1000
+    )
     cell_values = [
         int.from_bytes(data[start : start + 2], byteorder="big") / cell_divisor
         for start in range(5, 5 + min(cell_count, 16) * 2, 2)

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -14,7 +14,8 @@ BATTERY_VARIANT_PRO = "pro"
 BATTERY_VARIANT_RNGPRO = "rngpro"
 BatteryVariant = Literal["legacy", "pro", "rngpro"]
 
-BATTERY_PRO_NAME_PREFIXES = ("RNGRBP", "RNGC")
+BATTERY_RNGRBP_NAME_PREFIX = "RNGRBP"
+BATTERY_PRO_NAME_PREFIXES = (BATTERY_RNGRBP_NAME_PREFIX, "RNGC")
 BATTERY_RNGPRO_NAME_PREFIXES = ("RNGPRO",)
 BATTERY_LEGACY_NAME_PREFIX = "BT-TH-"
 BATTERY_LEGACY_NAME_MARKERS = ("BATT", "BATTERY")
@@ -44,6 +45,11 @@ BATTERY_COMMANDS: dict[str, tuple[int, int]] = {
 def clean_battery_text(value: bytes) -> str:
     """Decode ASCII battery metadata and strip padding."""
     return value.decode("ascii", errors="ignore").strip("\x00").strip()
+
+
+def is_rngr_bp_battery_name(name: str | None) -> bool:
+    """Return whether an advertisement belongs to the RNGRBP family."""
+    return (name or "").strip().startswith(BATTERY_RNGRBP_NAME_PREFIX)
 
 
 def detect_battery_variant(

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -9,10 +9,11 @@ BATTERY_DEVICE_TYPE = "battery"
 BATTERY_VARIANT_LEGACY = "legacy"
 BATTERY_VARIANT_PRO = "pro"
 # RNGPRO-family batteries (e.g. RBT12500LFP-SHBT) share the Pro register map and
-# device id but use different field scaling than RNGRBP/RNGC "pro" batteries:
-# current in 0.01 A units (not 0.1 A) and cell voltages in 0.1 V units (not mV).
+# device id but use 0.01 A current units rather than the Pro variant's 0.1 A.
+# Their 0.1 V cell units match RNGRBP; RNGC scaling remains unconfirmed.
 BATTERY_VARIANT_RNGPRO = "rngpro"
 BatteryVariant = Literal["legacy", "pro", "rngpro"]
+BatteryCellVoltageDivisor = Literal[10, 1000]
 
 BATTERY_RNGRBP_NAME_PREFIX = "RNGRBP"
 BATTERY_PRO_NAME_PREFIXES = (BATTERY_RNGRBP_NAME_PREFIX, "RNGC")
@@ -50,6 +51,17 @@ def clean_battery_text(value: bytes) -> str:
 def is_rngr_bp_battery_name(name: str | None) -> bool:
     """Return whether an advertisement belongs to the RNGRBP family."""
     return (name or "").strip().startswith(BATTERY_RNGRBP_NAME_PREFIX)
+
+
+def battery_cell_voltage_divisor(
+    name: str | None,
+    *,
+    variant: BatteryVariant,
+) -> BatteryCellVoltageDivisor:
+    """Return the cell-voltage divisor confirmed for an advertised family."""
+    if variant == BATTERY_VARIANT_RNGPRO or is_rngr_bp_battery_name(name):
+        return 10
+    return 1000
 
 
 def detect_battery_variant(
@@ -190,6 +202,7 @@ def parse_battery_cell_status(
     data: bytes,
     *,
     variant: BatteryVariant,
+    cell_voltage_divisor: BatteryCellVoltageDivisor | None = None,
 ) -> dict[str, Any]:
     """Parse cell voltages and temperature sensors."""
     parsed: dict[str, Any] = {}
@@ -197,13 +210,9 @@ def parse_battery_cell_status(
     cell_count = int.from_bytes(data[3:5], byteorder="big")
     parsed["cell_count"] = cell_count
 
-    # Cell voltage units differ by protocol variant: legacy reports millivolts,
-    # while the pro (RNGRBP/RNGC) and RNGPRO families report 0.1 V units. #120
-    # corrected the RNGPRO variant; the pro family scales the same way, confirmed
-    # on RNGRBP hardware (4 cells x 3.6 V = 14.4 V pack, matching the pack-voltage
-    # register read separately) and cyrils/renogy-bt.
-    cell_divisor = (
-        10 if variant in (BATTERY_VARIANT_RNGPRO, BATTERY_VARIANT_PRO) else 1000
+    cell_divisor = cell_voltage_divisor or battery_cell_voltage_divisor(
+        None,
+        variant=variant,
     )
     cell_values = [
         int.from_bytes(data[start : start + 2], byteorder="big") / cell_divisor

--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -57,11 +57,13 @@ def battery_cell_voltage_divisor(
     name: str | None,
     *,
     variant: BatteryVariant,
-) -> BatteryCellVoltageDivisor:
-    """Return the cell-voltage divisor confirmed for an advertised family."""
+) -> BatteryCellVoltageDivisor | None:
+    """Return a confirmed cell-voltage divisor, if the family identifies one."""
     if variant == BATTERY_VARIANT_RNGPRO or is_rngr_bp_battery_name(name):
         return 10
-    return 1000
+    if variant != BATTERY_VARIANT_PRO or (name or "").strip().startswith("RNGC"):
+        return 1000
+    return None
 
 
 def detect_battery_variant(
@@ -210,14 +212,21 @@ def parse_battery_cell_status(
     cell_count = int.from_bytes(data[3:5], byteorder="big")
     parsed["cell_count"] = cell_count
 
-    cell_divisor = cell_voltage_divisor or battery_cell_voltage_divisor(
-        None,
-        variant=variant,
-    )
-    cell_values = [
-        int.from_bytes(data[start : start + 2], byteorder="big") / cell_divisor
+    raw_cell_values = [
+        int.from_bytes(data[start : start + 2], byteorder="big")
         for start in range(5, 5 + min(cell_count, 16) * 2, 2)
     ]
+    cell_divisor = cell_voltage_divisor or battery_cell_voltage_divisor(
+        None, variant=variant
+    )
+    if cell_divisor is None:
+        # Manufacturer-only discovery does not identify whether a Pro pack is
+        # RNGRBP (0.1 V units) or RNGC (millivolts). A positive raw value below
+        # 100 would be under 0.1 V with millivolt encoding, so infer only that
+        # unambiguous case and preserve the millivolt default otherwise.
+        positive_values = [value for value in raw_cell_values if value > 0]
+        cell_divisor = 10 if positive_values and max(positive_values) < 100 else 1000
+    cell_values = [value / cell_divisor for value in raw_cell_values]
     if cell_values:
         parsed["cell_voltages"] = cell_values
         parsed["cell_voltage_min"] = min(cell_values)

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -25,6 +25,7 @@ from renogy_ble.battery import (
     BatteryVariant,
     build_battery_command,
     detect_battery_variant,
+    is_rngr_bp_battery_name,
     parse_battery_cell_status,
     parse_battery_device_info,
     parse_battery_mosfet_status,
@@ -215,6 +216,7 @@ class RenogyBLEDevice:
         self.address = ble_device.address
 
         cleaned_name = clean_device_name(ble_device.name)
+        self.advertised_name = cleaned_name
         self.name = cleaned_name or "Unknown Renogy Device"
 
         # Use the provided advertisement RSSI if available, otherwise set to None.
@@ -449,6 +451,7 @@ class _PersistentBleSession:
     # read response carries no register address, so it cannot be told apart from
     # the next command's reply. The session must be dropped rather than reused.
     desynchronized: bool = False
+    write_with_response: bool | None = None
 
 
 class RenogyBleClient:
@@ -696,16 +699,12 @@ class RenogyBleClient:
                         raise RuntimeError("BLE session is not connected")
 
                     request = build_battery_command(variant, register, word_count)
-                    # Renogy batteries' ffd1 write characteristic only accepts
-                    # BLE Write-Without-Response. A default (with-response) write
-                    # is rejected by the pack with ATT 0x0E "Unlikely Error",
-                    # which previously failed every battery poll. Confirmed on
-                    # RNGRBP (RBT12200LFP-BT) hardware, and matches DC Home's own
-                    # WRITE_NO_RESPONSE selection.
+                    # RNGRBP requires Write-Without-Response; other families use
+                    # the mode supported by their resolved characteristic.
                     await session.client.write_gatt_char(
                         session.write_target or self._write_char_uuid,
                         request,
-                        response=False,
+                        response=session.write_with_response,
                     )
                     try:
                         result_data = await self._wait_for_valid_read_response(
@@ -1273,6 +1272,9 @@ class RenogyBleClient:
             self._reset_notifications(session)
             session.read_target = self._read_char_uuid
             session.write_target = self._write_char_uuid
+            session.write_with_response = (
+                False if is_rngr_bp_battery_name(device.advertised_name) else None
+            )
             if device.device_type == BATTERY_DEVICE_TYPE:
                 self._resolve_battery_characteristics(device, session)
 
@@ -1308,6 +1310,7 @@ class RenogyBleClient:
 
         notify_handle = None
         write_handle = None
+        write_with_response = session.write_with_response
         notify_service_uuid = normalize_uuid_str(RENOGY_NOTIFY_SERVICE_UUID)
         write_service_uuid = normalize_uuid_str(RENOGY_WRITE_SERVICE_UUID)
         notify_char_uuid = normalize_uuid_str(self._read_char_uuid)
@@ -1324,12 +1327,21 @@ class RenogyBleClient:
                     and {"write", "write-without-response"} & properties
                 ):
                     write_handle = characteristic.handle
+                    if "write-without-response" in properties and (
+                        write_with_response is False or "write" not in properties
+                    ):
+                        write_with_response = False
+                    else:
+                        write_with_response = True
                 if (
                     service_uuid == notify_service_uuid
                     and char_uuid == notify_char_uuid
                     and "notify" in properties
                 ):
                     notify_handle = characteristic.handle
+
+        if write_handle is not None:
+            session.write_with_response = write_with_response
 
         if notify_handle is None or write_handle is None:
             logger.debug(
@@ -1380,6 +1392,7 @@ class RenogyBleClient:
         session.read_target = None
         session.write_target = None
         session.desynchronized = False
+        session.write_with_response = None
         self._reset_notifications(session)
 
         if remove:

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -211,13 +211,21 @@ class RenogyBLEDevice:
         advertisement_rssi: Optional[int] = None,
         device_type: str = DEFAULT_DEVICE_TYPE,
         manufacturer_data: dict[int, bytes] | None = None,
+        advertisement_name: str | None = None,
     ):
         """Initialize the Renogy BLE device."""
         self.ble_device = ble_device
         self.address = ble_device.address
 
         cleaned_name = clean_device_name(ble_device.name)
-        self.advertised_name = cleaned_name
+        # BLEDevice.name is an OS name and is not guaranteed to be the local
+        # name from the advertisement. Callers with AdvertisementData should
+        # pass its local_name so family-specific protocol behavior is reliable.
+        self.advertised_name = (
+            clean_device_name(advertisement_name)
+            if advertisement_name
+            else cleaned_name
+        )
         self.name = cleaned_name or "Unknown Renogy Device"
 
         # Use the provided advertisement RSSI if available, otherwise set to None.
@@ -234,7 +242,10 @@ class RenogyBLEDevice:
         self.device_type = device_type
         self.last_unavailable_time: Optional[datetime] = None
         self.battery_variant: BatteryVariant | None = (
-            detect_battery_variant(self.name, manufacturer_data=self.manufacturer_data)
+            detect_battery_variant(
+                self.advertised_name,
+                manufacturer_data=self.manufacturer_data,
+            )
             if device_type == BATTERY_DEVICE_TYPE
             else None
         )
@@ -1338,9 +1349,7 @@ class RenogyBleClient:
                     and {"write", "write-without-response"} & properties
                 ):
                     write_handle = characteristic.handle
-                    if "write-without-response" in properties and (
-                        write_with_response is False or "write" not in properties
-                    ):
+                    if "write-without-response" in properties:
                         write_with_response = False
                     else:
                         write_with_response = True

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -696,9 +696,16 @@ class RenogyBleClient:
                         raise RuntimeError("BLE session is not connected")
 
                     request = build_battery_command(variant, register, word_count)
+                    # Renogy batteries' ffd1 write characteristic only accepts
+                    # BLE Write-Without-Response. A default (with-response) write
+                    # is rejected by the pack with ATT 0x0E "Unlikely Error",
+                    # which previously failed every battery poll. Confirmed on
+                    # RNGRBP (RBT12200LFP-BT) hardware, and matches DC Home's own
+                    # WRITE_NO_RESPONSE selection.
                     await session.client.write_gatt_char(
                         session.write_target or self._write_char_uuid,
                         request,
+                        response=False,
                     )
                     try:
                         result_data = await self._wait_for_valid_read_response(

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -23,6 +23,7 @@ from renogy_ble.battery import (
     BATTERY_PROTOCOL_DEVICE_IDS,
     BATTERY_VARIANT_LEGACY,
     BatteryVariant,
+    battery_cell_voltage_divisor,
     build_battery_command,
     detect_battery_variant,
     is_rngr_bp_battery_name,
@@ -692,6 +693,10 @@ class RenogyBleClient:
                 # Preserve stable metadata that can be reused across polls.
                 parsed_updates = dict(device.parsed_data)
                 device_id = BATTERY_PROTOCOL_DEVICE_IDS[variant]
+                cell_voltage_divisor = battery_cell_voltage_divisor(
+                    device.advertised_name,
+                    variant=variant,
+                )
 
                 for cmd_name, (register, word_count) in BATTERY_COMMANDS.items():
                     self._reset_notifications(session)
@@ -720,13 +725,19 @@ class RenogyBleClient:
                         # to its request, so stop using this session.
                         break
 
-                    parser = {
-                        "device_info": parse_battery_device_info,
-                        "pack_status": parse_battery_pack_status,
-                        "cell_status": parse_battery_cell_status,
-                        "mosfet_status": parse_battery_mosfet_status,
-                    }[cmd_name]
-                    parsed = parser(result_data, variant=variant)
+                    if cmd_name == "cell_status":
+                        parsed = parse_battery_cell_status(
+                            result_data,
+                            variant=variant,
+                            cell_voltage_divisor=cell_voltage_divisor,
+                        )
+                    else:
+                        parser = {
+                            "device_info": parse_battery_device_info,
+                            "pack_status": parse_battery_pack_status,
+                            "mosfet_status": parse_battery_mosfet_status,
+                        }[cmd_name]
+                        parsed = parser(result_data, variant=variant)
                     if not parsed:
                         logger.info(
                             "Failed to parse battery command %s from device %s",

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -113,6 +113,30 @@ def test_parse_battery_pack_status_preserves_fractional_capacity() -> None:
     assert parsed["battery_percentage"] == 50.3
 
 
+def test_parse_battery_cell_status_pro_uses_tenth_volt_scale() -> None:
+    """Pro packs report cell voltage in 0.1 V units (raw x 0.1)."""
+    payload = bytearray(68)
+    payload[0:2] = (4).to_bytes(2, "big")
+    # 4 cells of 3.6 V summing to the 14.4 V pack voltage, as seen on RNGRBP.
+    for index, value in enumerate((36, 36, 36, 36)):
+        start = 2 + index * 2
+        payload[start : start + 2] = value.to_bytes(2, "big")
+    payload[34:36] = (3).to_bytes(2, "big")
+    payload[36:38] = (234).to_bytes(2, "big", signed=True)
+    payload[38:40] = (231).to_bytes(2, "big", signed=True)
+    payload[40:42] = (233).to_bytes(2, "big", signed=True)
+
+    cell_frame = _battery_frame(0xFF, bytes(payload))
+    parsed = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_PRO)
+
+    assert parsed["cell_count"] == 4
+    assert parsed["cell_voltages"] == [3.6, 3.6, 3.6, 3.6]
+    assert parsed["cell_voltage_min"] == 3.6
+    assert parsed["cell_voltage_max"] == 3.6
+    assert parsed["cell_voltage_delta"] == 0.0
+    assert parsed["battery_temperature"] == 23.3
+
+
 def test_parse_battery_cell_status_and_faults() -> None:
     """Cell and fault parsing should expose derived metrics."""
     payload = bytearray(68)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -3,6 +3,8 @@
 from renogy_ble.battery import (
     BATTERY_VARIANT_LEGACY,
     BATTERY_VARIANT_PRO,
+    BATTERY_VARIANT_RNGPRO,
+    battery_cell_voltage_divisor,
     build_battery_command,
     detect_battery_variant,
     is_supported_battery_name,
@@ -113,8 +115,8 @@ def test_parse_battery_pack_status_preserves_fractional_capacity() -> None:
     assert parsed["battery_percentage"] == 50.3
 
 
-def test_parse_battery_cell_status_pro_uses_tenth_volt_scale() -> None:
-    """Pro packs report cell voltage in 0.1 V units (raw x 0.1)."""
+def test_parse_battery_cell_status_rngr_bp_uses_tenth_volt_scale() -> None:
+    """RNGRBP packs report cell voltage in 0.1 V units (raw x 0.1)."""
     payload = bytearray(68)
     payload[0:2] = (4).to_bytes(2, "big")
     # 4 cells of 3.6 V summing to the 14.4 V pack voltage, as seen on RNGRBP.
@@ -127,7 +129,14 @@ def test_parse_battery_cell_status_pro_uses_tenth_volt_scale() -> None:
     payload[40:42] = (233).to_bytes(2, "big", signed=True)
 
     cell_frame = _battery_frame(0xFF, bytes(payload))
-    parsed = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_PRO)
+    parsed = parse_battery_cell_status(
+        cell_frame,
+        variant=BATTERY_VARIANT_PRO,
+        cell_voltage_divisor=battery_cell_voltage_divisor(
+            "RNGRBP123456",
+            variant=BATTERY_VARIANT_PRO,
+        ),
+    )
 
     assert parsed["cell_count"] == 4
     assert parsed["cell_voltages"] == [3.6, 3.6, 3.6, 3.6]
@@ -135,6 +144,37 @@ def test_parse_battery_cell_status_pro_uses_tenth_volt_scale() -> None:
     assert parsed["cell_voltage_max"] == 3.6
     assert parsed["cell_voltage_delta"] == 0.0
     assert parsed["battery_temperature"] == 23.3
+
+
+def test_battery_cell_voltage_divisor_scopes_tenth_volt_families() -> None:
+    """Only hardware-confirmed families should use the tenth-volt scale."""
+    assert (
+        battery_cell_voltage_divisor("RNGRBP123456", variant=BATTERY_VARIANT_PRO) == 10
+    )
+    assert (
+        battery_cell_voltage_divisor(
+            "RNGPRO125BAT-EF036881", variant=BATTERY_VARIANT_RNGPRO
+        )
+        == 10
+    )
+    assert (
+        battery_cell_voltage_divisor("RNGC123456", variant=BATTERY_VARIANT_PRO) == 1000
+    )
+    assert battery_cell_voltage_divisor("Unknown", variant=BATTERY_VARIANT_PRO) == 1000
+
+
+def test_parse_battery_cell_status_pro_defaults_to_millivolt_scale() -> None:
+    """Generic Pro parsing should preserve the established millivolt default."""
+    payload = bytearray(68)
+    payload[0:2] = (4).to_bytes(2, "big")
+    for index, value in enumerate((3300, 3300, 3310, 3310)):
+        start = 2 + index * 2
+        payload[start : start + 2] = value.to_bytes(2, "big")
+
+    cell_frame = _battery_frame(0xFF, bytes(payload))
+    parsed = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_PRO)
+
+    assert parsed["cell_voltages"] == [3.3, 3.3, 3.31, 3.31]
 
 
 def test_parse_battery_cell_status_and_faults() -> None:

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -160,7 +160,7 @@ def test_battery_cell_voltage_divisor_scopes_tenth_volt_families() -> None:
     assert (
         battery_cell_voltage_divisor("RNGC123456", variant=BATTERY_VARIANT_PRO) == 1000
     )
-    assert battery_cell_voltage_divisor("Unknown", variant=BATTERY_VARIANT_PRO) == 1000
+    assert battery_cell_voltage_divisor("Unknown", variant=BATTERY_VARIANT_PRO) is None
 
 
 def test_parse_battery_cell_status_pro_defaults_to_millivolt_scale() -> None:
@@ -175,6 +175,20 @@ def test_parse_battery_cell_status_pro_defaults_to_millivolt_scale() -> None:
     parsed = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_PRO)
 
     assert parsed["cell_voltages"] == [3.3, 3.3, 3.31, 3.31]
+
+
+def test_parse_battery_cell_status_unknown_pro_infers_tenth_volt_scale() -> None:
+    """Manufacturer-only Pro discovery should recognize unambiguous 0.1 V data."""
+    payload = bytearray(68)
+    payload[0:2] = (4).to_bytes(2, "big")
+    for index, value in enumerate((33, 33, 34, 34)):
+        start = 2 + index * 2
+        payload[start : start + 2] = value.to_bytes(2, "big")
+
+    cell_frame = _battery_frame(0xFF, bytes(payload))
+    parsed = parse_battery_cell_status(cell_frame, variant=BATTERY_VARIANT_PRO)
+
+    assert parsed["cell_voltages"] == [3.3, 3.3, 3.4, 3.4]
 
 
 def test_parse_battery_cell_status_and_faults() -> None:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -82,6 +82,20 @@ def test_create_modbus_write_request_defaults_function_code():
     assert frame[6:] == bytes([crc_low, crc_high])
 
 
+def test_device_uses_explicit_advertisement_name_for_battery_family() -> None:
+    """The advertisement local name should override a generic BLE OS name."""
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="Generic OS name"),
+        device_type="battery",
+        manufacturer_data={0xE14C: b"\x01"},
+        advertisement_name="RNGRBP123456",
+    )
+
+    assert device.name == "Generic OS name"
+    assert device.advertised_name == "RNGRBP123456"
+    assert device.battery_variant == BATTERY_VARIANT_PRO
+
+
 def test_extract_valid_read_response_skips_junk_prefix():
     client = RenogyBleClient()
     payload = bytes([DEFAULT_DEVICE_ID, 0x03, 0x02, 0x12, 0x34])
@@ -849,6 +863,7 @@ def test_read_device_falls_back_to_legacy_variant_for_manual_bt_th_battery(
     ("write_properties", "expected_response"),
     [
         (["write-without-response"], False),
+        (["write", "write-without-response"], False),
         (["write"], True),
     ],
 )

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -562,7 +562,7 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
 
             cell_payload = bytearray(68)
             cell_payload[0:2] = (4).to_bytes(2, "big")
-            for index, value in enumerate((330, 330, 331, 331)):
+            for index, value in enumerate((33, 33, 33, 33)):
                 start = 2 + index * 2
                 cell_payload[start : start + 2] = value.to_bytes(2, "big")
             cell_payload[34:36] = (1).to_bytes(2, "big")
@@ -607,6 +607,7 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
     assert result.parsed_data["battery_current"] == 123.4
     assert result.parsed_data["battery_percentage"] == 65.0
     assert result.parsed_data["battery_cycle_count"] == 7
+    assert result.parsed_data["cell_voltages"] == [3.3, 3.3, 3.3, 3.3]
     assert result.parsed_data["battery_temperature"] == 23.0
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
@@ -705,7 +706,7 @@ def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch)
 
             cell_payload = bytearray(68)
             cell_payload[0:2] = (4).to_bytes(2, "big")
-            for index, value in enumerate((330, 330, 331, 331)):
+            for index, value in enumerate((3300, 3300, 3310, 3310)):
                 start = 2 + index * 2
                 cell_payload[start : start + 2] = value.to_bytes(2, "big")
             cell_payload[34:36] = (1).to_bytes(2, "big")
@@ -749,6 +750,7 @@ def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch)
 
     assert result.success is True
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert result.parsed_data["cell_voltages"] == [3.3, 3.3, 3.31, 3.31]
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
@@ -932,7 +934,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(
 
             cell_payload = bytearray(68)
             cell_payload[0:2] = (4).to_bytes(2, "big")
-            for index, value in enumerate((330, 330, 331, 331)):
+            for index, value in enumerate((33, 33, 33, 33)):
                 start = 2 + index * 2
                 cell_payload[start : start + 2] = value.to_bytes(2, "big")
             cell_payload[34:36] = (1).to_bytes(2, "big")
@@ -975,6 +977,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(
 
     assert result.success is True
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert result.parsed_data["cell_voltages"] == [3.3, 3.3, 3.3, 3.3]
     assert dummy_client.start_notify_targets[0] == 33
     assert dummy_client.write_targets == [17] * 4
     assert dummy_client.write_responses == [expected_response] * 4
@@ -1060,7 +1063,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_all_match(
 
             cell_payload = bytearray(68)
             cell_payload[0:2] = (4).to_bytes(2, "big")
-            for index, value in enumerate((330, 330, 331, 331)):
+            for index, value in enumerate((33, 33, 33, 33)):
                 start = 2 + index * 2
                 cell_payload[start : start + 2] = value.to_bytes(2, "big")
             cell_payload[34:36] = (1).to_bytes(2, "big")
@@ -1103,6 +1106,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_all_match(
 
     assert result.success is True
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
+    assert result.parsed_data["cell_voltages"] == [3.3, 3.3, 3.3, 3.3]
     assert dummy_client.start_notify_targets[0] == RENOGY_READ_CHAR_UUID
     assert dummy_client.write_targets == [RENOGY_WRITE_CHAR_UUID] * 4
     assert dummy_client.write_responses == [True] * 4

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -843,7 +843,18 @@ def test_read_device_falls_back_to_legacy_variant_for_manual_bt_th_battery(
     assert [request[0] for request in dummy_client.writes] == [0x30] * 4
 
 
-def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monkeypatch):
+@pytest.mark.parametrize(
+    ("write_properties", "expected_response"),
+    [
+        (["write-without-response"], False),
+        (["write"], True),
+    ],
+)
+def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(
+    monkeypatch,
+    write_properties: list[str],
+    expected_response: bool,
+):
     class DummyCharacteristic:
         def __init__(self, uuid: str, handle: int, properties: list[str]):
             self.uuid = uuid
@@ -862,6 +873,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monke
             self.stop_notify_calls = 0
             self.start_notify_targets: list[int | str] = []
             self.write_targets: list[int | str] = []
+            self.write_responses: list[bool | None] = []
             self._notify_handler: Callable[[object | None, bytes], None] | None = None
             self.services = [
                 DummyService(
@@ -870,7 +882,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monke
                         DummyCharacteristic(
                             "0000ffd1-0000-1000-8000-00805f9b34fb",
                             17,
-                            ["write-without-response"],
+                            write_properties,
                         )
                     ],
                 ),
@@ -896,6 +908,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monke
 
             request = bytes(payload)
             self.write_targets.append(target)
+            self.write_responses.append(response)
             register = int.from_bytes(request[2:4], "big")
 
             def _frame(device_id: int, payload_bytes: bytes) -> bytes:
@@ -964,9 +977,10 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monke
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
     assert dummy_client.start_notify_targets[0] == 33
     assert dummy_client.write_targets == [17] * 4
+    assert dummy_client.write_responses == [expected_response] * 4
 
 
-def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
+def test_read_device_falls_back_to_uuid_when_battery_services_do_not_all_match(
     monkeypatch,
 ):
     class DummyCharacteristic:
@@ -987,15 +1001,16 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
             self.stop_notify_calls = 0
             self.start_notify_targets: list[int | str] = []
             self.write_targets: list[int | str] = []
+            self.write_responses: list[bool | None] = []
             self._notify_handler: Callable[[object | None, bytes], None] | None = None
             self.services = [
                 DummyService(
-                    "00001234-0000-1000-8000-00805f9b34fb",
+                    "0000ffd0-0000-1000-8000-00805f9b34fb",
                     [
                         DummyCharacteristic(
                             "0000ffd1-0000-1000-8000-00805f9b34fb",
                             17,
-                            ["write-without-response"],
+                            ["write"],
                         )
                     ],
                 ),
@@ -1021,6 +1036,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
 
             request = bytes(payload)
             self.write_targets.append(target)
+            self.write_responses.append(response)
             register = int.from_bytes(request[2:4], "big")
 
             def _frame(device_id: int, payload_bytes: bytes) -> bytes:
@@ -1089,6 +1105,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_PRO
     assert dummy_client.start_notify_targets[0] == RENOGY_READ_CHAR_UUID
     assert dummy_client.write_targets == [RENOGY_WRITE_CHAR_UUID] * 4
+    assert dummy_client.write_responses == [True] * 4
 
 
 def test_read_device_battery_stops_after_command_timeout(monkeypatch):

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -271,7 +271,7 @@ def test_read_device_reads_inverter_data_with_validated_frames(monkeypatch):
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -432,7 +432,7 @@ def test_read_device_reads_legacy_battery_data(monkeypatch):
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -533,7 +533,7 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -611,6 +611,59 @@ def test_read_device_reads_battery_pro_data(monkeypatch):
     assert [request[0] for request in dummy_client.writes] == [0xFF] * 4
 
 
+def test_read_device_writes_battery_without_response(monkeypatch):
+    """Battery ffd1 only accepts Write-Without-Response; a with-response write is
+    rejected by the pack with ATT 0x0E. Every battery command must pass
+    response=False (regression guard for the RNGRBP "Unlikely Error" bug)."""
+
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.responses: list[object] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _target, payload, response=None):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+            self.responses.append(response)
+            request = bytes(payload)
+            register = int.from_bytes(request[2:4], "big")
+            # Minimal valid frames so the read loop completes for every command.
+            sizes = {0x13F0: 56, 0x13B2: 14, 0x1388: 68, 0x13EC: 16}
+            body = bytearray([0xFF, 0x03, sizes[register]]) + bytearray(sizes[register])
+            crc_low, crc_high = modbus_crc(body)
+            body.extend([crc_low, crc_high])
+            self._notify_handler(None, bytes(body))
+
+        async def stop_notify(self, *_args, **_kwargs):
+            pass
+
+        async def disconnect(self):
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient()
+    device = RenogyBLEDevice(
+        _mock_ble_device(name="RNGRBP123456"), device_type="battery"
+    )
+
+    asyncio.run(client.read_device(device))
+
+    assert dummy_client.responses, "no battery writes were issued"
+    assert all(response is False for response in dummy_client.responses)
+
+
 def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch):
     class DummyClient:
         def __init__(self):
@@ -623,7 +676,7 @@ def test_read_device_detects_battery_variant_from_manufacturer_data(monkeypatch)
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -713,7 +766,7 @@ def test_read_device_falls_back_to_legacy_variant_for_manual_bt_th_battery(
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -837,7 +890,7 @@ def test_read_device_uses_resolved_handles_for_battery_pro_characteristics(monke
             self.start_notify_targets.append(target)
             self._notify_handler = callback
 
-        async def write_gatt_char(self, target, payload):
+        async def write_gatt_char(self, target, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -962,7 +1015,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
             self.start_notify_targets.append(target)
             self._notify_handler = callback
 
-        async def write_gatt_char(self, target, payload):
+        async def write_gatt_char(self, target, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -1050,7 +1103,7 @@ def test_read_device_battery_stops_after_command_timeout(monkeypatch):
         async def start_notify(self, *_args, **_kwargs):
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             self.writes.append(bytes(payload))
 
         async def stop_notify(self, *_args, **_kwargs):
@@ -1151,7 +1204,7 @@ def test_read_device_battery_drops_stale_partial_poll_data(monkeypatch):
             self.start_notify_calls += 1
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             self.writes.append(bytes(payload))
 
         async def stop_notify(self, *_args, **_kwargs):
@@ -1320,7 +1373,7 @@ def test_read_device_inverter_preserves_cached_metadata_in_persistent_session(
             self.start_notify_calls += 1
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
 
@@ -1743,7 +1796,7 @@ def test_persistent_session_reuses_connection_for_writes(monkeypatch):
             self.start_notify_calls += 1
             self._notify_handler = _args[1]
 
-        async def write_gatt_char(self, _uuid, payload):
+        async def write_gatt_char(self, _uuid, payload, response=None):
             if self._notify_handler is None:
                 raise AssertionError("Notify handler was not set.")
             self._notify_handler(None, bytes(payload))


### PR DESCRIPTION
**Benefit:** Makes Renogy RNGRBP (RBT12200LFP-BT) "BT Battery Pro" packs actually work over BLE. Two independent bugs: battery polls that fail outright, and pro-family cell voltages left on the wrong scale after #120.

Rebased on current `main` (post-#120).

## What this fixes

- **Every battery poll fails.** The `ffd1` write characteristic only accepts BLE Write-Without-Response; a default with-response write is rejected by the pack with ATT `0x0E` "Unlikely Error", before any Modbus content matters. Sending with `response=False` (matching DC Home's own `WRITE_NO_RESPONSE` selection) fixes it. Confirmed on RNGRBP hardware. This path is unaffected by #120.

- **Pro-family cell voltages read ~100× low.** #120 corrected the **RNGPRO** variant to 0.1 V units but left the **pro** variant (RNGRBP/RNGC) on the millivolt scale. The pro family scales the same way — this extends #120's `cell_divisor` ÷10 branch to the pro variant.

### Why 0.1 V is correct for the pro variant (not an assumption)

On RNGRBP the pack reports its **total voltage from a separate register** (`pack_status`) than the per-cell registers (`cell_status`). The two only reconcile at 0.1 V:

- 0.1 V scale: 4 cells × 3.6 V = **14.4 V** ✓ (matches the independently-read pack-voltage register)
- mV scale: 4 × 0.036 V = **0.144 V** ✗ (100× off, and physically impossible for a LiFePO4 cell)

This also matches `cyrils/renogy-bt`, which scales these packs at 0.1 V.

**Caveat:** the `pro` variant also covers `RNGC`, which was not available to test here. `cyrils/renogy-bt` treats RNGRBP and RNGC identically, but a maintainer confirmation on RNGC would be welcome.

## Tests

Adds coverage for both fixes. All quality gates pass in a single run: `ruff format`, `ruff check`, `ty check`, `pytest` (81 tests, including #120's RNGPRO fixtures).
