### PR TITLE
fix: scale DCC solar cutoff current to amps

### DIFF
--- a/src/renogy_ble/register_map.py
+++ b/src/renogy_ble/register_map.py
@@ -557,6 +557,7 @@ REGISTER_MAP: RegisterMap = {
             "register": 57400,  # 0xE038
             "length": 2,
             "byte_order": "big",
+            "scale": 0.01,  # Convert centiamps to amps
             "offset": 3,
         },
     },

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -374,8 +374,9 @@ def test_dcc_reverse_charging_voltage_parsing():
 def test_dcc_solar_cutoff_current_parsing():
     """Test parsing DCC solar cutoff current from its dedicated register."""
     parser = RenogyBaseParser()
-    data = bytes([0xFF, 0x03, 0x02, 0x00, 0x07, 0x00, 0x00])  # 7A
+    # The device reports centiamps, like every other DCC current register.
+    data = bytes([0xFF, 0x03, 0x02, 0x02, 0xBC, 0x00, 0x00])  # 700 -> 7.0A
 
     result = parser.parse(data, "dcc", 57400)
 
-    assert result["solar_cutoff_current"] == 7
+    assert result["solar_cutoff_current"] == 7.0


### PR DESCRIPTION
## Problem

`solar_cutoff_current` (register `0xE038`) is reported by the DCC in centiamps, but it is the only current field in the DCC register map without a `scale` factor. Setting **7 A** in the official Renogy app made Home Assistant read **700**.

Every other current register on the same device already scales by `0.01`:

| Field | Register | Scale |
|---|---|---|
| `total_charging_current` | `0x0100` | `0.01` |
| `alternator_current` | `0x0100` | `0.01` |
| `solar_current` | `0x0100` | `0.01` |
| `daily_max_charging_current` | `0x0100` | `0.01` |
| `max_charging_current` | `0xE001` | `0.01` — comment reads *"Convert centiamps to amps"* |
| `solar_cutoff_current` | `0xE038` | **missing** |

## Verification on real hardware

Tested against a live DCC50S (`BT-TH-6A8CB538`) on Home Assistant `2026.7.4`, reading the recorder database directly:

- Before the change, the entity recorded `700.0` while the app was set to 7 A.
- After the change, the same register read `7.0`, held across two BLE reconnects.
- Setting **3 A** in the app afterwards read back as `3.0`.

## Test

`test_dcc_solar_cutoff_current_parsing` asserted the unscaled behaviour from a synthetic frame that had never been checked against a device. It now feeds a 700-centiamp response and expects `7.0` A.

## Note for the integration side

`renogy-ha` writes this register too, and its `number` entity currently sends the raw amp value. I have a matching PR ready there; it needs a release of this library first so the pin can be bumped. Happy to sequence them however you prefer.