### PR TITLE
fix: drop the BLE session after a read timeout

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -1412,7 +1412,11 @@ class RenogyBleClient:
                 session.desynchronized = True
                 raise asyncio.TimeoutError()
 
-            await asyncio.wait_for(session.notification_event.wait(), remaining)
+            try:
+                await asyncio.wait_for(session.notification_event.wait(), remaining)
+            except asyncio.TimeoutError:
+                session.desynchronized = True
+                raise
             session.notification_event.clear()
 
     async def _wait_for_write_response(

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -435,6 +435,10 @@ class _PersistentBleSession:
     notify_started: bool = False
     read_target: int | str | None = None
     write_target: int | str | None = None
+    # Set when a read times out. The reply may still be in flight, and a Modbus
+    # read response carries no register address, so it cannot be told apart from
+    # the next command's reply. The session must be dropped rather than reused.
+    desynchronized: bool = False
 
 
 class RenogyBleClient:
@@ -552,7 +556,9 @@ class RenogyBleClient:
                             device_name=device.name,
                         )
                     except asyncio.TimeoutError:
-                        continue
+                        # The response stream is desynchronized; a late reply to
+                        # this command would be misread as the next command's.
+                        break
 
                     logger.debug(
                         "Received valid %s data length: %s",
@@ -589,7 +595,7 @@ class RenogyBleClient:
                 )
                 error = exc
 
-            if error is not None:
+            if error is not None or session.desynchronized:
                 await self._close_session(
                     device.address,
                     device.name,
@@ -694,7 +700,9 @@ class RenogyBleClient:
                             device_name=device.name,
                         )
                     except asyncio.TimeoutError:
-                        continue
+                        # See _read_device_data: a late reply cannot be matched
+                        # to its request, so stop using this session.
+                        break
 
                     parser = {
                         "device_info": parse_battery_device_info,
@@ -731,7 +739,7 @@ class RenogyBleClient:
                 )
                 error = exc
 
-            if error is not None:
+            if error is not None or session.desynchronized:
                 await self._close_session(
                     device.address,
                     device.name,
@@ -833,6 +841,10 @@ class RenogyBleClient:
                         retries=spec.retries,
                     )
                     if result_data is None:
+                        if session.desynchronized:
+                            # See _read_device_data: a late reply cannot be
+                            # matched to its request, so stop using this session.
+                            break
                         continue
 
                     parser = getattr(self, spec.parser_name)
@@ -864,7 +876,7 @@ class RenogyBleClient:
                 )
                 error = exc
 
-            if error is not None:
+            if error is not None or session.desynchronized:
                 await self._close_session(
                     device.address,
                     device.name,
@@ -1290,6 +1302,7 @@ class RenogyBleClient:
         session.notify_started = False
         session.read_target = None
         session.write_target = None
+        session.desynchronized = False
         self._reset_notifications(session)
 
         if remove:
@@ -1396,6 +1409,7 @@ class RenogyBleClient:
                     max(len(session.notification_data), expected_len),
                     device_name,
                 )
+                session.desynchronized = True
                 raise asyncio.TimeoutError()
 
             await asyncio.wait_for(session.notification_event.wait(), remaining)

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -960,7 +960,7 @@ def test_read_device_falls_back_to_uuid_when_battery_services_do_not_match(
     assert dummy_client.write_targets == [RENOGY_WRITE_CHAR_UUID] * 4
 
 
-def test_read_device_battery_continues_after_command_timeout(monkeypatch):
+def test_read_device_battery_stops_after_command_timeout(monkeypatch):
     class DummyClient:
         def __init__(self):
             self.is_connected = True
@@ -1023,6 +1023,7 @@ def test_read_device_battery_continues_after_command_timeout(monkeypatch):
         **_kwargs,
     ):
         if cmd_name == "battery cell_status":
+            _session.desynchronized = True
             raise asyncio.TimeoutError()
 
         return responses[cmd_name]
@@ -1048,10 +1049,12 @@ def test_read_device_battery_continues_after_command_timeout(monkeypatch):
     assert result.parsed_data["battery_variant"] == BATTERY_VARIANT_LEGACY
     assert result.parsed_data["battery_voltage"] == 51.2
     assert result.parsed_data["battery_current"] == 12.34
-    assert result.parsed_data["charge_mosfet_enabled"] is True
     assert "battery_temperature" not in result.parsed_data
     assert device.name == "House Battery 1"
-    assert len(dummy_client.writes) == 4
+    # The poll stops at the timed-out command rather than issuing mosfet_status,
+    # because a late reply could be misread as that command's response.
+    assert "charge_mosfet_enabled" not in result.parsed_data
+    assert len(dummy_client.writes) == 3
     assert dummy_client.stop_notify_calls == 1
     assert dummy_client.disconnect_calls == 1
 
@@ -1379,6 +1382,89 @@ def test_persistent_session_reuses_connection_for_reads(monkeypatch):
     assert establish_calls == 1
     assert dummy_client.start_notify_calls == 1
     assert dummy_client.stop_notify_calls == 1
+    assert dummy_client.disconnect_calls == 1
+
+
+def test_read_device_stops_after_read_timeout_instead_of_misreading_reply(monkeypatch):
+    """A late reply must not be attributed to the command that follows it.
+
+    Modbus read responses carry no register address, so a reply that arrives
+    after its own command timed out is indistinguishable from the next
+    command's reply whenever both read the same number of words. The DCC reads
+    reverse_charging_voltage (0xE020) and solar_cutoff_current (0xE038) back to
+    back and both are single-word, which made a 12.7 V reading surface as a
+    solar cutoff current of 127.
+    """
+
+    def _single_word_frame(value: int) -> bytes:
+        payload = bytes(
+            [DEFAULT_DEVICE_ID, 0x03, 0x02, (value >> 8) & 0xFF, value & 0xFF]
+        )
+        crc_low, crc_high = modbus_crc(payload)
+        return payload + bytes([crc_low, crc_high])
+
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.stop_notify_calls = 0
+            self.requested_registers: list[int] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            register = (payload[2] << 8) | payload[3]
+            self.requested_registers.append(register)
+
+            if register == 57376:  # 0xE020: reply withheld, so the read times out.
+                return
+            if register == 57400:  # 0xE038: would be served 0xE020's late reply.
+                self._notify_handler(None, _single_word_frame(127))
+                return
+
+            self._notify_handler(None, _single_word_frame(5000))
+
+        async def stop_notify(self, *_args, **_kwargs):
+            self.stop_notify_calls += 1
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    dummy_client = DummyClient()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(
+        commands={
+            "dcc": {
+                "current_limit": (3, 57345, 1),
+                "reverse_charging_voltage": (3, 57376, 1),
+                "solar_cutoff_current": (3, 57400, 1),
+            }
+        },
+        max_notification_wait_time=0.01,
+    )
+    device = RenogyBLEDevice(_mock_ble_device(name="BT-TH-DCC01"), device_type="dcc")
+
+    result = asyncio.run(client.read_device(device))
+
+    # 0xE020's late reply must never be decoded as a solar cutoff current.
+    assert "solar_cutoff_current" not in result.parsed_data
+    # The poll stops at the timeout, so the stale reply is never collected.
+    assert dummy_client.requested_registers == [57345, 57376]
+    # Data read before the timeout is kept.
+    assert result.parsed_data["max_charging_current"] == 50.0
     assert dummy_client.disconnect_calls == 1
 
 

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -16,6 +16,7 @@ from renogy_ble.ble import (
     BleakError,
     RenogyBleClient,
     RenogyBLEDevice,
+    RenogyBleReadResult,
     clean_device_name,
     create_modbus_read_request,
     create_modbus_write_request,
@@ -1466,6 +1467,106 @@ def test_read_device_stops_after_read_timeout_instead_of_misreading_reply(monkey
     # Data read before the timeout is kept.
     assert result.parsed_data["max_charging_current"] == 50.0
     assert dummy_client.disconnect_calls == 1
+
+
+def test_read_timeout_reconnects_before_next_persistent_session_poll(monkeypatch):
+    """A timed-out persistent session must not be reused by the next poll."""
+
+    clients = []
+
+    class DummyClient:
+        def __init__(self, connection_number: int):
+            self.connection_number = connection_number
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self.requested_registers: list[int] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            register = (payload[2] << 8) | payload[3]
+            self.requested_registers.append(register)
+
+            if self.connection_number == 1:
+                if self.requested_registers == [0]:
+                    self._notify_handler(
+                        None, _modbus_read_response(DEFAULT_DEVICE_ID, [100])
+                    )
+                elif self.requested_registers == [0, 1]:
+                    return
+                elif self.requested_registers == [0, 1, 0]:
+                    # This is register 1's late reply. If the timed-out session
+                    # is reused, it is indistinguishable from register 0's reply.
+                    self._notify_handler(
+                        None, _modbus_read_response(DEFAULT_DEVICE_ID, [200])
+                    )
+                else:
+                    self._notify_handler(
+                        None, _modbus_read_response(DEFAULT_DEVICE_ID, [400])
+                    )
+                return
+
+            response_value = 300 if register == 0 else 400
+            self._notify_handler(
+                None, _modbus_read_response(DEFAULT_DEVICE_ID, [response_value])
+            )
+
+        async def stop_notify(self, *_args, **_kwargs):
+            pass
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        dummy_client = DummyClient(len(clients) + 1)
+        clients.append(dummy_client)
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(
+        commands={"test_device": {"first": (3, 0, 1), "second": (3, 1, 1)}},
+        max_notification_wait_time=0.01,
+        transport_mode="persistent_session",
+    )
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="test_device")
+    parsed_values: list[tuple[int, int]] = []
+
+    def _update_parsed_data(
+        raw_data: bytes, register: int, cmd_name: str = "unknown"
+    ) -> bool:
+        _ = cmd_name
+        parsed_values.append((register, int.from_bytes(raw_data[3:5], "big")))
+        return True
+
+    monkeypatch.setattr(device, "update_parsed_data", _update_parsed_data)
+
+    async def _run() -> tuple[RenogyBleReadResult, RenogyBleReadResult]:
+        first = await client.read_device(device)
+        second = await client.read_device(device)
+        await client.close_device(device)
+        return first, second
+
+    first_result, second_result = asyncio.run(_run())
+
+    assert first_result.success is True
+    assert first_result.error is None
+    assert second_result.success is True
+    assert second_result.error is None
+    assert len(clients) == 2
+    assert clients[0].requested_registers == [0, 1]
+    assert clients[0].disconnect_calls == 1
+    assert clients[1].requested_registers == [0, 1]
+    assert clients[1].disconnect_calls == 1
+    assert parsed_values == [(0, 100), (0, 300), (1, 400)]
 
 
 def test_read_device_uses_valid_frame_when_notification_has_prefixed_junk(monkeypatch):


### PR DESCRIPTION
## Problem

A Modbus **read** response carries no register address. The only things distinguishing one reply from another are the device id, function code and byte count — all of which `_extract_valid_read_response` checks, and none of which identify *which* register was read.

When a read times out, the command loop moves on:

```python
except asyncio.TimeoutError:
    continue
```

The next iteration clears the notification buffer and sends its own request. A late reply to the *previous* command now lands in that cleared buffer, and `_wait_for_valid_read_response` returns **as soon as any valid frame is present** — so it takes the stale frame. `update_parsed_data` is then called with the *new* command's register, and the old value is decoded under the wrong field's map.

## This is reachable on the DCC

The byte-count check means a stale frame can only be consumed by a read of the same word count. In `COMMANDS["dcc"]`:

```
device_info(8w)  device_id(1w)  dynamic_data(32w)  status(8w)
current_limit(1w)  parameters(18w)  reverse_charging_voltage(1w)  solar_cutoff_current(1w)
```

`device_id` is followed by a 32-word read and `current_limit` by an 18-word read, both rejected on length. **`reverse_charging_voltage` → `solar_cutoff_current` is the only adjacent same-length pair**, and it is exactly the one that misbehaves in the field.

Observed on a live DCC50S: `reverse_charging_voltage` is `12.7` (raw `127`) in all 1113 numeric samples in the Home Assistant recorder, never any other value — and `solar_cutoff_current` recorded `127` five times over eight days. No error was logged and each poll was reported successful, because the timeout at step one logs only at `logger.info`.

The new test reproduces it against the unpatched code:

```
parsed_data={'max_charging_current': 50.0, 'solar_cutoff_current': 127}
success=True, error=None
```

## Fix

Mark the session desynchronized when a read times out, stop the poll there, and close the session so the next poll starts on a clean connection.

This is **what `write_single_register` already does** for write timeouts (`ble.py:1054` closes with `remove=True`); reads were simply inconsistent with it. No timing heuristic or grace period is involved — once a reply may be in flight and cannot be identified, the connection is the only safe thing to discard.

Applied to all three read loops (`_read_device_data`, `_read_battery_device`, the inverter specs), since they share the flaw. `BATTERY_COMMANDS` happens to have four distinct word counts today, so the battery path is currently safe by accident rather than by design.

## Trade-off

Data parsed before the timeout is still returned; the remaining commands are picked up by the next poll. So a timeout costs the tail of one cycle instead of risking a wrong value in an entity. I took the view that a silently misattributed reading is worse than a delayed one, but I am happy to switch to a narrower fix (drain-and-retry, or reordering `COMMANDS` so no two same-length reads are adjacent) if you would rather not lose the rest of the cycle.

## Tests

`test_read_device_battery_continues_after_command_timeout` asserted the old behaviour, so it is renamed to `..._stops_after_command_timeout` and updated — this is an intentional contract change, flagged here for review.

Added `test_read_device_stops_after_read_timeout_instead_of_misreading_reply`, which drives the real `_wait_for_valid_read_response` with a short `max_notification_wait_time`, withholds `0xE020`'s reply, and offers it when `0xE038` is requested. It fails on `main` with `solar_cutoff_current: 127` and passes with this change.

## Related

Separate from #127, which fixes the scaling of `solar_cutoff_current`. This PR is independent and touches different lines.