### PR TITLE
fix: declare the DCC status fields under the register that is actually read

### DIFF
--- a/src/renogy_ble/register_map.py
+++ b/src/renogy_ble/register_map.py
@@ -380,27 +380,27 @@ REGISTER_MAP: RegisterMap = {
         },
         # Fault information (register 289-290 / 0x0121-0x0122)
         "fault_high": {
-            "register": 289,
+            "register": 288,
             "length": 2,
             "byte_order": "big",
-            "offset": 3,
+            "offset": 5,
         },
         "fault_low": {
-            "register": 290,
+            "register": 288,
             "length": 2,
             "byte_order": "big",
-            "offset": 3,
+            "offset": 7,
         },
         # Output power (register 292 / 0x0124)
         "output_power": {
-            "register": 292,
+            "register": 288,
             "length": 2,
             "byte_order": "big",
-            "offset": 3,
+            "offset": 11,
         },
         # Charging mode (register 293 / 0x0125)
         "charging_mode": {
-            "register": 293,
+            "register": 288,
             "length": 2,
             "byte_order": "big",
             "map": {
@@ -411,15 +411,15 @@ REGISTER_MAP: RegisterMap = {
                 4: "solar_alternator_to_house",
                 5: "solar_to_starter",
             },
-            "offset": 3,
+            "offset": 13,
         },
         # Ignition signal (register 294 / 0x0126)
         "ignition_status": {
-            "register": 294,
+            "register": 288,
             "length": 2,
             "byte_order": "big",
             "map": {0: "disconnected", 1: "connected"},
-            "offset": 3,
+            "offset": 15,
         },
         # Maximum charging current (register 57345 / 0xE001)
         # Stored as centiamps (100x), so 4000 = 40A

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -380,3 +380,46 @@ def test_dcc_solar_cutoff_current_parsing():
     result = parser.parse(data, "dcc", 57400)
 
     assert result["solar_cutoff_current"] == 7.0
+
+
+def test_every_dcc_field_is_reachable_by_some_command():
+    """A field must live under a register some command actually asks for.
+
+    ``RenogyBaseParser.parse`` matches a field to a response by exact start
+    register, and the only call site passes a command's *start* register. A
+    field declared under any other register is therefore unreachable on every
+    device -- it can never appear in parsed output.
+    """
+    from renogy_ble.ble import COMMANDS
+    from renogy_ble.register_map import REGISTER_MAP
+
+    starts = {register for _fn, register, _words in COMMANDS["dcc"].values()}
+    orphans = {
+        name: field["register"]
+        for name, field in REGISTER_MAP["dcc"].items()
+        if field.get("register") not in starts
+    }
+    assert not orphans, f"unreachable DCC fields: {orphans}"
+
+
+def test_dcc_status_block_parses_every_field():
+    """Parse a real status frame captured from a DCC50S (RBC2125DS-21W-).
+
+    ff 03 0e | 0002 0000 0000 0000 010b 0004 0000
+    addr/fn/len then 7 words. The 267 W in ``output_power`` was corroborated
+    live by ``alternator_power`` reading 265 W at the same moment, and
+    ``charging_mode`` 4 (solar_alternator_to_house) agreed with
+    ``charging_status`` 2 (mppt) -- two registers telling the same story,
+    which is what pins the byte offsets.
+    """
+    from renogy_ble.parser import DCCParser
+
+    frame = bytes.fromhex("ff030e" "0002" "0000" "0000" "0000" "010b" "0004" "0000")
+    parsed = DCCParser().parse_data(frame, register=288)
+
+    assert parsed["charging_status"] == "mppt"
+    assert parsed["fault_high"] == 0
+    assert parsed["fault_low"] == 0
+    assert parsed["output_power"] == 267
+    assert parsed["charging_mode"] == "solar_alternator_to_house"
+    assert parsed["ignition_status"] == "disconnected"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -414,7 +414,7 @@ def test_dcc_status_block_parses_every_field():
     """
     from renogy_ble.parser import DCCParser
 
-    frame = bytes.fromhex("ff030e" "0002" "0000" "0000" "0000" "010b" "0004" "0000")
+    frame = bytes.fromhex("ff030e0002000000000000010b00040000")
     parsed = DCCParser().parse_data(frame, register=288)
 
     assert parsed["charging_status"] == "mppt"


### PR DESCRIPTION
### The bug

`RenogyBaseParser.parse` matches a field to a response by **exact start register**, and the only call site passes a command's *start* register (`ble.py`, `register=cmd[1]`). `COMMANDS["dcc"]` contains 12, 26, 256, 288, 57345, 57347, 57376 and 57400 — so these five fields match no response and are unreachable:

| field | declared register |
|---|---|
| `fault_high` | 289 |
| `fault_low` | 290 |
| `output_power` | 292 |
| `charging_mode` | 293 |
| `ignition_status` | 294 |

This is a property of the code, not of any particular charger: no DCC model can make register 289 match, because no command starts at 289. These five have never appeared in parsed output on any device.

### Why these offsets are not device-specific

They are arithmetic from the register numbers already in the map, not measurements from my charger. Every field in the DCC map is declared under its block's **start** register with `offset` encoding its position in the frame — 45 of the 50 fields follow that convention, including all 22 of the register-256 block and all 17 of the 57347 block. These five are the only deviants. Applying the map's own convention to the map's own register numbers:

```
offset = 3 + 2 * (register - 288)

fault_high       289 -> 5
fault_low        290 -> 7
output_power     292 -> 11
charging_mode    293 -> 13
ignition_status  294 -> 15
```

So this preserves your register semantics exactly and re-expresses them in the scheme the rest of the map already uses. Both halves must change together — leaving `offset: 3` would make all five read the same first word.

### An alternative you may prefer

These five declarations could instead be left untouched and given their own single-register reads, `(3, 289, 1)` and so on — `offset: 3` is already correct for a one-word response, so the existing entries are self-consistent under that design.

I did not take that route because the 8-word `status` read already fetches registers 288–295, so the data is in hand and those reads would ask for it a second time. It would also take the DCC poll from 8 commands to 13 (+62% round trips), which is a real cost on a marginal BLE link and gives late replies more chances to land in the next command's buffer. **Happy to switch if you would rather keep the register numbers as the source of truth.**

### Verification

Live frame from a DCC50S (`RBC2125DS-21W-`):

```
ff 03 0e | 0002 0000 0000 0000 010b 0004 0000
```

`output_power` (offset 11) reads 267 W while `alternator_power` reported 265 W at the same moment, and `charging_mode` (offset 13) reads 4 (`solar_alternator_to_house`), agreeing with `charging_status` at offset 4 reading 2 (`mppt`). Two registers telling the same physical story, which pins the offsets rather than merely making them self-consistent.

### Tests

- `test_dcc_status_block_parses_every_field` — parses the captured frame and asserts all six values.
- `test_every_dcc_field_is_reachable_by_some_command` — a general guard so this class of bug cannot return: every DCC field must be reachable by some command's start register. It fails on `main` and passes here.

Full suite green (81 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
