### PR TITLE
ci: credit authors in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
+      "include-commit-authors": true,
       "release-type": "python",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- enable Release Please's `include-commit-authors` option
- append contributor usernames or names to generated changelog and GitHub release-note entries
- preserve the existing Conventional Commit section layout

## Impact

Visible release-note entries will include an author credit such as `(@rpodgorny)`. Commit types already hidden by the current changelog configuration remain hidden.

## Validation

- `jq empty release-please-config.json`
- `git diff --check`
