### PR TITLE
fix: serve the DCC status tail from dynamic_data on G6 units

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -592,7 +592,13 @@ class RenogyBleClient:
             try:
                 logger.debug("Connected to device %s", device.name)
 
-                for cmd_name, cmd in commands.items():
+                command_items = list(commands.items())
+                if device.device_type == "dcc":
+                    # Model-specific DCC command handling needs device_info first.
+                    # Preserve the caller's order for every other command.
+                    command_items.sort(key=lambda item: item[1][1] != 12)
+
+                for cmd_name, cmd in command_items:
                     adjusted_cmd = self._adjust_dcc_command_for_model(
                         device, cmd_name, cmd
                     )

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -98,6 +98,18 @@ COMMANDS = {
     },
 }
 
+# G6-generation DCC units (model suffix "-G6", e.g. RBC50D1S-G6) never answer
+# the discrete status read at 0x0120 -- the request times out on every poll.
+# Because a read timeout desynchronizes the notification stream, the timeout
+# also aborts every command queued after "status" and tears down the session.
+# The same firmware does answer a 34-word read at 0x0100, whose tail covers
+# 0x0120-0x0121 (charging_status and fault_high); registers beyond 0x0121
+# appear not to exist on G6 hardware, so a request spanning them fails as a
+# whole. For G6 models the "status" command is therefore skipped and
+# "dynamic_data" is extended to cover the status tail instead.
+DCC_G6_MODEL_SUFFIX = "-G6"
+DCC_G6_DYNAMIC_DATA_WORDS = 34  # 0x0100-0x0121
+
 
 def modbus_crc(data: bytes | bytearray) -> tuple[int, int]:
     """Calculate the Modbus CRC16 of the given data.
@@ -496,6 +508,32 @@ class RenogyBleClient:
         self._persistent_sessions: dict[str, _PersistentBleSession] = {}
         self._persistent_sessions_guard = asyncio.Lock()
 
+    @staticmethod
+    def _adjust_dcc_command_for_model(
+        device: RenogyBLEDevice,
+        cmd_name: str,
+        cmd: tuple[int, int, int],
+    ) -> tuple[int, int, int] | None:
+        """Return the command to send to this device, or None to skip it.
+
+        The model string parsed from the device_info command earlier in the
+        same poll cycle identifies G6-generation DCC units, which never answer
+        the discrete status read and need the dynamic_data read extended to
+        cover the status tail instead (see DCC_G6_MODEL_SUFFIX).
+        """
+        if device.device_type != "dcc":
+            return cmd
+        model = device.parsed_data.get("model")
+        if not isinstance(model, str) or not model.strip().upper().endswith(
+            DCC_G6_MODEL_SUFFIX
+        ):
+            return cmd
+        if cmd_name == "status":
+            return None
+        if cmd_name == "dynamic_data":
+            return (cmd[0], cmd[1], DCC_G6_DYNAMIC_DATA_WORDS)
+        return cmd
+
     async def read_device(self, device: RenogyBLEDevice) -> RenogyBleReadResult:
         """Connect to a device, fetch data, and return parsed results."""
         if device.device_type == BATTERY_DEVICE_TYPE:
@@ -555,6 +593,18 @@ class RenogyBleClient:
                 logger.debug("Connected to device %s", device.name)
 
                 for cmd_name, cmd in commands.items():
+                    adjusted_cmd = self._adjust_dcc_command_for_model(
+                        device, cmd_name, cmd
+                    )
+                    if adjusted_cmd is None:
+                        logger.debug(
+                            "Skipping %s command for G6 DCC device %s",
+                            cmd_name,
+                            device.name,
+                        )
+                        continue
+                    cmd = adjusted_cmd
+
                     self._reset_notifications(session)
 
                     modbus_request = create_modbus_read_request(self._device_id, *cmd)

--- a/src/renogy_ble/parser.py
+++ b/src/renogy_ble/parser.py
@@ -131,6 +131,39 @@ class RenogyBaseParser:
         if self._fields_by_register is not None:
             self._fields_by_register = _index_register_fields(value)
 
+    def _iter_response_fields(self, model: str, register: int, payload_end: int | None):
+        """Yield ``(field_name, field_info, offset)`` readable from a response.
+
+        Fields declared under the response's own start register always parse at
+        their declared offset. Fields declared under another command's start
+        register are additionally included when the response payload actually
+        covers their registers -- their offset is shifted by the register
+        distance. This lets a longer read serve the fields of a command a
+        device never answers (e.g. G6 DCC units, which reject the discrete
+        status read at 0x0120 but answer a 34-word read at 0x0100 covering
+        0x0120-0x0121).
+        """
+        if self._fields_by_register is None:
+            groups: dict[int, list[tuple[str, FieldInfo]]] = {}
+            for field_name, field_info in self.register_map[model].items():
+                group = field_info.get("register")
+                if group is not None:
+                    groups.setdefault(group, []).append((field_name, field_info))
+            grouped_fields = groups.items()
+        else:
+            grouped_fields = self._fields_by_register.get(model, {}).items()
+
+        for group, fields in grouped_fields:
+            if group == register:
+                for field_name, field_info in fields:
+                    yield field_name, field_info, field_info["offset"]
+            elif payload_end is not None:
+                shift = 2 * (group - register)
+                for field_name, field_info in fields:
+                    offset = field_info["offset"] + shift
+                    if offset >= 3 and offset + field_info["length"] <= payload_end:
+                        yield field_name, field_info, offset
+
     def parse(
         self, data: bytes, model: str, register: int
     ) -> dict[str, int | float | str]:
@@ -144,7 +177,8 @@ class RenogyBaseParser:
 
         Returns:
             dict: A dictionary containing the parsed values for fields belonging to
-                the specified register
+                the specified register, plus any fields from other register blocks
+                that this response's payload happens to cover
         """
         result: dict[str, int | float | str] = {}
 
@@ -152,17 +186,15 @@ class RenogyBaseParser:
             logger.warning("Unsupported model: %s", model)
             return result
 
-        if self._fields_by_register is None:
-            fields = (
-                (field_name, field_info)
-                for field_name, field_info in self.register_map[model].items()
-                if field_info.get("register") == register
-            )
-        else:
-            fields = self._fields_by_register.get(model, {}).get(register, ())
+        # End of the Modbus payload (3-byte header + byte count), bounded by
+        # the actual frame length so a lying byte count cannot over-read.
+        payload_end: int | None = None
+        if len(data) > 2:
+            payload_end = min(3 + data[2], len(data))
 
-        for field_name, field_info in fields:
-            offset = field_info["offset"]
+        for field_name, field_info, offset in self._iter_response_fields(
+            model, register, payload_end
+        ):
             length = field_info["length"]
             byte_order = field_info["byte_order"]
             scale = field_info.get("scale")

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -2152,6 +2152,40 @@ def test_g6_dcc_skips_status_and_reads_it_from_dynamic_data(monkeypatch):
     assert result.parsed_data["max_charging_current"] == 50.0
 
 
+def test_g6_dcc_reads_device_info_before_reordered_custom_commands(monkeypatch):
+    """Custom DCC command order must not bypass G6 model detection."""
+    dummy_client, requests = _dcc_g6_dummy_client_and_requests()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    reordered_commands = {
+        "dcc": {
+            "status": (3, 288, 8),
+            "dynamic_data": (3, 256, 32),
+            "current_limit": (3, 57345, 1),
+            "device_info": (3, 12, 8),
+        }
+    }
+    client = RenogyBleClient(
+        commands=reordered_commands,
+        max_notification_wait_time=0.01,
+    )
+    device = RenogyBLEDevice(_mock_ble_device(name="BT-TH-A58A8FD4"), device_type="dcc")
+
+    result = asyncio.run(client.read_device(device))
+
+    assert requests[0] == (12, 8)
+    assert (288, 8) not in requests
+    assert (256, 34) in requests
+    assert result.parsed_data["charging_status"] == "mppt"
+    assert result.parsed_data["max_charging_current"] == 50.0
+
+
 def test_non_g6_dcc_keeps_discrete_status_read(monkeypatch):
     """A non-G6 DCC keeps the 32-word dynamic read and the status command."""
     dummy_client, requests = _dcc_g6_dummy_client_and_requests()

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -2051,3 +2051,141 @@ def test_update_parsed_data_rejects_bit_flipped_payload(monkeypatch):
     assert result is False
     # The pre-existing valid reading must be preserved, not overwritten with garbage.
     assert device.parsed_data.get("battery_voltage") == 13.0
+
+
+def _dcc_g6_dummy_client_and_requests():
+    """Build a DummyClient that answers like an RBC50D1S-G6 charger."""
+    requests: list[tuple[int, int]] = []
+
+    class DummyClient:
+        def __init__(self):
+            self.is_connected = True
+            self.disconnect_calls = 0
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            register = (payload[2] << 8) | payload[3]
+            word_count = (payload[4] << 8) | payload[5]
+            requests.append((register, word_count))
+
+            if register == 12:
+                self._notify_handler(
+                    None,
+                    _modbus_ascii_response(DEFAULT_DEVICE_ID, "RBC50D1S-G6", 8),
+                )
+            elif register == 256:
+                # 34-word dynamic_data with the status tail: 0x0120 low byte
+                # carries charging_status 2 (mppt), 0x0121 carries fault_high.
+                words = [0] * word_count
+                if word_count >= 34:
+                    words[32] = 0x0002
+                    words[33] = 0x0000
+                self._notify_handler(
+                    None, _modbus_read_response(DEFAULT_DEVICE_ID, words)
+                )
+            elif register == 57345:
+                self._notify_handler(
+                    None, _modbus_read_response(DEFAULT_DEVICE_ID, [5000])
+                )
+            # register 288 (status) deliberately gets NO reply, like real G6
+            # hardware -- reaching it at all is the regression this guards.
+
+        async def stop_notify(self, *_args, **_kwargs):
+            pass
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    return DummyClient(), requests
+
+
+_DCC_TEST_COMMANDS = {
+    "dcc": {
+        "device_info": (3, 12, 8),
+        "dynamic_data": (3, 256, 32),
+        "status": (3, 288, 8),
+        "current_limit": (3, 57345, 1),
+    }
+}
+
+
+def test_g6_dcc_skips_status_and_reads_it_from_dynamic_data(monkeypatch):
+    """A -G6 DCC must never be sent the status command it cannot answer.
+
+    G6 firmware times out the discrete 0x0120 read; the timeout would abort
+    every later command and tear down the session. The model parsed from
+    device_info in the same poll must instead extend dynamic_data to 34 words
+    and skip status entirely, with charging_status served from the tail.
+    """
+    dummy_client, requests = _dcc_g6_dummy_client_and_requests()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(
+        commands=_DCC_TEST_COMMANDS,
+        max_notification_wait_time=0.01,
+    )
+    device = RenogyBLEDevice(_mock_ble_device(name="BT-TH-A58A8FD4"), device_type="dcc")
+
+    result = asyncio.run(client.read_device(device))
+
+    requested_registers = [register for register, _words in requests]
+    assert 288 not in requested_registers
+    assert (256, 34) in requests
+    assert result.parsed_data["model"] == "RBC50D1S-G6"
+    assert result.parsed_data["charging_status"] == "mppt"
+    assert result.parsed_data["fault_high"] == 0
+    # Commands after "status" must still run -- on current code the status
+    # timeout would have broken the loop before current_limit.
+    assert result.parsed_data["max_charging_current"] == 50.0
+
+
+def test_non_g6_dcc_keeps_discrete_status_read(monkeypatch):
+    """A non-G6 DCC keeps the 32-word dynamic read and the status command."""
+    dummy_client, requests = _dcc_g6_dummy_client_and_requests()
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        return dummy_client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    # Same frames, but the device identifies as a non-G6 DCC50S-family model.
+    original_write = dummy_client.write_gatt_char
+
+    async def _write(_uuid, payload):
+        register = (payload[2] << 8) | payload[3]
+        if register == 12:
+            requests.append((register, (payload[4] << 8) | payload[5]))
+            dummy_client._notify_handler(
+                None,
+                _modbus_ascii_response(DEFAULT_DEVICE_ID, "RBC2125DS-21W", 8),
+            )
+            return
+        await original_write(_uuid, payload)
+
+    dummy_client.write_gatt_char = _write
+
+    client = RenogyBleClient(
+        commands=_DCC_TEST_COMMANDS,
+        max_notification_wait_time=0.01,
+    )
+    device = RenogyBLEDevice(_mock_ble_device(name="BT-TH-DCC01"), device_type="dcc")
+
+    asyncio.run(client.read_device(device))
+
+    assert (256, 32) in requests
+    assert (288, 8) in requests

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -464,10 +464,12 @@ def test_dcc_solar_cutoff_current_parsing():
 def test_every_dcc_field_is_reachable_by_some_command():
     """A field must live under a register some command actually asks for.
 
-    ``RenogyBaseParser.parse`` matches a field to a response by exact start
-    register, and the only call site passes a command's *start* register. A
-    field declared under any other register is therefore unreachable on every
-    device -- it can never appear in parsed output.
+    ``RenogyBaseParser.parse`` matches a field to a response primarily by
+    exact start register (the windowed fallback only triggers when a longer
+    response happens to cover another block, which no command guarantees). A
+    field declared under a register no command asks for is therefore
+    unreachable on every device -- it can never reliably appear in parsed
+    output.
     """
     from renogy_ble.ble import COMMANDS
     from renogy_ble.register_map import REGISTER_MAP
@@ -502,3 +504,65 @@ def test_dcc_status_block_parses_every_field():
     assert parsed["output_power"] == 267
     assert parsed["charging_mode"] == "solar_alternator_to_house"
     assert parsed["ignition_status"] == "disconnected"
+
+
+def _dcc_dynamic_data_frame(words: list[int]) -> bytes:
+    """Build a Modbus read response frame for the given register words."""
+    frame = bytearray([0xFF, 0x03, len(words) * 2])
+    for word in words:
+        frame.extend(word.to_bytes(2, "big"))
+    frame.extend([0x00, 0x00])  # placeholder CRC; parse() does not validate it
+    return bytes(frame)
+
+
+def test_dcc_extended_dynamic_data_serves_status_tail():
+    """A 34-word dynamic_data read covers 0x0120-0x0121, the G6 status tail.
+
+    G6-generation DCC units never answer the discrete status read at 0x0120
+    but do answer a 34-word read at 0x0100 (proven by running an RBC50D1S-G6
+    as device type "controller", whose pv command reads 34 words, for a
+    year). The windowed parse must surface charging_status and fault_high
+    from that tail while leaving the fields past 0x0121 -- which the response
+    does not cover -- absent rather than parsed from garbage.
+    """
+    from renogy_ble.renogy_parser import RenogyParser
+
+    words = [0] * 34
+    words[0] = 84  # battery_soc (0x0100)
+    words[32] = 0x0002  # 0x0120 low byte: charging_status = 2 (mppt)
+    words[33] = 0x0000  # 0x0121: fault_high
+    frame = _dcc_dynamic_data_frame(words)
+
+    # Uncached parser path.
+    parsed = DCCParser().parse_data(frame, register=256)
+    # Cached (indexed) parser path used by the RenogyParser singletons.
+    parsed_cached = RenogyParser.parse(frame, "dcc", 256)
+
+    for result in (parsed, parsed_cached):
+        assert result["battery_soc"] == 84
+        assert result["charging_status"] == "mppt"
+        assert result["fault_high"] == 0
+        for absent in (
+            "fault_low",
+            "output_power",
+            "charging_mode",
+            "ignition_status",
+        ):
+            assert absent not in result
+
+
+def test_dcc_standard_dynamic_data_has_no_status_fields():
+    """A 32-word dynamic_data read must not pick up any status field."""
+    frame = _dcc_dynamic_data_frame([0] * 32)
+
+    parsed = DCCParser().parse_data(frame, register=256)
+
+    for absent in (
+        "charging_status",
+        "fault_high",
+        "fault_low",
+        "output_power",
+        "charging_mode",
+        "ignition_status",
+    ):
+        assert absent not in parsed


### PR DESCRIPTION
## Problem

G6-generation DCC chargers never answer the discrete status read at 0x0120.
The `status` command `(3, 288, 8)` times out on every poll, so
`charging_status`, `charging_mode`, `ignition_status`, `output_power` and the
fault fields are permanently unknown for these units.

Since #128 (released in 2.4.1), a read timeout also desynchronizes the
notification stream and tears down the session — correct in general, but on a
G6 it means every poll now aborts at `status`, losing the four commands queued
after it (`current_limit`, `parameters`, `reverse_charging_voltage`,
`solar_cutoff_current`) and reconnecting BLE each cycle. So on 2.4.1 a G6
loses all writable-parameter data, not just the status block.

Hardware: **RBC50D1S-G6** ("DCC50S new version", 12 V 50 A, BT-2 module
`BT-TH-A58A8FD4`, device fw 8.0.6), running as device type `dcc` via
renogy-ha (detected by IAmTheMitchell/renogy-ha#173's model-based detection).

Live log, stock 2.4.1 (debug level; the four config commands are never sent,
and the coordinator update that follows contains only device_info +
dynamic_data fields):

```
21:56:51.128 DEBUG [renogy_ble.ble] Sending dynamic_data command: [255, 3, 1, 0, 0, 32, 80, 48]
21:56:51.241 DEBUG [renogy_ble.ble] Sending status command: [255, 3, 1, 32, 0, 8, 81, 228]
21:56:55.178 DEBUG [renogy_ble.ble] Disconnected from device BT-TH-A58A8FD4
```

## Why the data is still reachable

The same firmware answers a **34-word read at 0x0100** whose tail covers
0x0120–0x0121. This is proven in the field: an RBC50D1S-G6 ran for a year as
device type `controller` — whose `pv` command reads `(3, 256, 34)` — and
`charging_status` parsed correctly from that tail the whole time. The
official Renogy app also displays a live charging mode on this unit, so the
data exists and Renogy's own client reads it.

Registers beyond 0x0121 appear not to exist on G6 hardware: a request
spanning them fails as a whole, which matches standard Modbus handling of
partially implemented ranges (and explains why the 8-word read at 0x0120
gets no answer while the 34-word read at 0x0100 always does).

## Fix

- **ble.py** — when the model parsed from `device_info` earlier in the same
  poll ends in `-G6`, skip the `status` command and extend `dynamic_data`
  from 32 to 34 words.
- **parser.py** — additionally include fields declared under another
  command's start register when the response payload actually covers their
  registers, shifting the offset by the register distance (bounded by the
  Modbus byte count, so CRC bytes can never be read as data). The 34-word
  DCC `dynamic_data` response therefore yields `charging_status` and
  `fault_high`; fields past 0x0121 stay absent instead of parsing garbage.

Non-G6 DCC units are unchanged: they keep the 32-word `dynamic_data` read
and the discrete `status` read (the captured RBC2125DS status-frame test
still passes unchanged). Controller, battery, shunt and inverter paths are
untouched.

## What G6 users get

| Field | Before | After |
|---|---|---|
| `charging_status` | unknown | ✅ works |
| `fault_high` | unknown | ✅ works |
| `current_limit` / `parameters` / `reverse_charging_voltage` / `solar_cutoff_current` (on ≥ 2.4.1) | lost every poll | ✅ restored |
| session | torn down + reconnected every poll (on ≥ 2.4.1) | ✅ one clean session |
| `charging_mode`, `ignition_status`, `output_power`, `fault_low` | unknown | unknown (registers absent on G6) |

## Verification

Unit tests: 4 new tests (windowed parse on both the cached and uncached
parser paths; G6 and non-G6 client command flows). Full suite: 108 passed;
`ruff format`, `ruff check`, `ty check` clean.

Live validation on the RBC50D1S-G6 (Home Assistant 2026.8.2, this branch
installed as a wheel over renogy-ha v0.8.0-beta.3): first poll after
restart —

```
21:59:50.849 DEBUG [renogy_ble.ble] Sending device_info command: [255, 3, 0, 12, 0, 8, 145, 209]
21:59:50.940 DEBUG [renogy_ble.ble] Sending device_id command: [255, 3, 0, 26, 0, 1, 176, 19]
21:59:50.985 DEBUG [renogy_ble.ble] Sending dynamic_data command: [255, 3, 1, 0, 0, 34, 209, 241]
21:59:51.098 DEBUG [renogy_ble.ble] Skipping status command for G6 DCC device BT-TH-A58A8FD4
21:59:51.098 DEBUG [renogy_ble.ble] Sending current_limit command: [255, 3, 224, 1, 0, 1, 247, 212]
21:59:51.142 DEBUG [renogy_ble.ble] Sending parameters command: [255, 3, 224, 3, 0, 18, 23, 217]
21:59:51.225 DEBUG [renogy_ble.ble] Sending reverse_charging_voltage command: [255, 3, 224, 32, 0, 1, 167, 222]
21:59:51.269 DEBUG [renogy_ble.ble] Sending solar_cutoff_current command: [255, 3, 224, 56, 0, 1, 39, 217]
21:59:53.175 DEBUG [renogy_ble.ble] Disconnected from device BT-TH-A58A8FD4
```

The coordinator update from that poll contains `'charging_status':
'standby', 'fault_high': 0` (correct — parked at night, nothing charging)
plus the full parameters block — the first time these fields have populated
on this unit. All entities recovered; the four absent-register fields stay
unknown as intended.
