### PR TITLE
feat: expose Communication Hub battery current and power

### DIFF
--- a/src/renogy_ble/battery.py
+++ b/src/renogy_ble/battery.py
@@ -215,6 +215,7 @@ def parse_hub_battery_pack_status(data: bytes) -> dict[str, Any]:
     if len(data) < expected_length or data[2] < HUB_BATTERY_PACK_STATUS_WORD_COUNT * 2:
         return {}
 
+    battery_current = int.from_bytes(data[3:5], byteorder="big", signed=True) / 100
     battery_voltage = int.from_bytes(data[5:7], byteorder="big") / 10
     battery_remaining_capacity = int.from_bytes(data[7:11], byteorder="big") / 1000
     battery_capacity = int.from_bytes(data[11:15], byteorder="big") / 1000
@@ -222,6 +223,8 @@ def parse_hub_battery_pack_status(data: bytes) -> dict[str, Any]:
     parsed: dict[str, Any] = {
         "slave_id": data[0],
         "battery_voltage": round(battery_voltage, 1),
+        "battery_current": round(battery_current, 2),
+        "battery_power": round(battery_voltage * battery_current, 3),
         "battery_remaining_capacity": round(battery_remaining_capacity, 3),
         "battery_capacity": battery_capacity,
     }

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -129,7 +129,7 @@ def test_parse_battery_pack_status_preserves_fractional_capacity() -> None:
 
 
 def test_parse_hub_battery_pack_status_from_captured_response() -> None:
-    """Parse validated Hub voltage and capacity fields without guessing current."""
+    """Parse validated Hub pack telemetry from a captured response."""
     frame = bytes.fromhex("30030c014601f80000c2840000c34d96d6")
 
     parsed = parse_hub_battery_pack_status(frame)
@@ -137,12 +137,27 @@ def test_parse_hub_battery_pack_status_from_captured_response() -> None:
     assert parsed == {
         "slave_id": 0x30,
         "battery_voltage": 50.4,
+        "battery_current": 3.26,
+        "battery_power": 164.304,
         "battery_remaining_capacity": 49.796,
         "battery_capacity": 49.997,
         "battery_percentage": 99.6,
     }
-    assert "battery_current" not in parsed
-    assert "battery_power" not in parsed
+
+
+def test_parse_hub_battery_pack_status_preserves_signed_current() -> None:
+    """Hub current and power should preserve charging and discharging direction."""
+    payload = bytearray(12)
+    payload[0:2] = (-123).to_bytes(2, "big", signed=True)
+    payload[2:4] = (512).to_bytes(2, "big")
+    payload[4:8] = (40000).to_bytes(4, "big")
+    payload[8:12] = (50000).to_bytes(4, "big")
+    frame = _battery_frame(0x30, bytes(payload))
+
+    parsed = parse_hub_battery_pack_status(frame)
+
+    assert parsed["battery_current"] == -1.23
+    assert parsed["battery_power"] == -62.976
 
 
 def test_parse_hub_battery_pack_status_preserves_slave_identity() -> None:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -187,8 +187,8 @@ def test_hub_requests_are_read_only_pack_status_reads(monkeypatch) -> None:
     assert len(dummy_client.writes) == 1
     request = dummy_client.writes[0]
     assert request[:6] == bytes([0x30, 0x03, 0x13, 0xB2, 0x00, 0x06])
-    assert "battery_current" not in result.batteries[0].parsed_data
-    assert "battery_power" not in result.batteries[0].parsed_data
+    assert result.batteries[0].parsed_data["battery_current"] == 3.26
+    assert result.batteries[0].parsed_data["battery_power"] == 164.304
 
 
 def test_hub_cached_timeout_preserves_discovery_and_drops_session(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Expose battery current and derived power for Communication Hub child batteries.

The Hub already reads register `0x13B2` with 6 words. This change decodes the existing signed current field from that response using the validated 0.01 A scale and derives battery power from voltage × current. No additional Modbus/BLE requests are added.

## Changes

- decode signed Hub battery current from the existing pack-status response
- expose derived battery power
- preserve charge/discharge sign for both values
- update Hub tests to expect the new telemetry
- add coverage using a captured Communication Hub response

## Validation

- 133 tests passed
- Ruff format check passed
- Ruff lint check passed
- `ty check` passed
- `git diff --check` passed

The current scaling and field position were previously validated against real Communication Hub battery data.