### PR TITLE
fix: recover controller polling after read timeout

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -614,7 +614,7 @@ class RenogyBleClient:
                     # Preserve the caller's order for every other command.
                     command_items.sort(key=lambda item: item[1][1] != 12)
 
-                for cmd_name, cmd in command_items:
+                for command_index, (cmd_name, cmd) in enumerate(command_items):
                     adjusted_cmd = self._adjust_dcc_command_for_model(
                         device, cmd_name, cmd
                     )
@@ -655,7 +655,37 @@ class RenogyBleClient:
                     except asyncio.TimeoutError:
                         # The response stream is desynchronized; a late reply to
                         # this command would be misread as the next command's.
-                        break
+                        if (
+                            device.device_type != DEFAULT_DEVICE_TYPE
+                            or command_index == len(command_items) - 1
+                        ):
+                            break
+
+                        # Some controllers do not answer every register block.
+                        # Continue on a new connection so a delayed reply cannot
+                        # be mistaken for the next command's response.
+                        await self._close_session(
+                            device.address,
+                            device.name,
+                            session,
+                            remove=False,
+                        )
+                        try:
+                            await self._ensure_session_ready(device, session)
+                        except Exception as reconnect_error:
+                            logger.info(
+                                "Failed to recover BLE session for device %s: %s",
+                                device.name,
+                                str(reconnect_error),
+                            )
+                            error = reconnect_error
+                            break
+                        logger.debug(
+                            "Reconnected to device %s after %s timed out",
+                            device.name,
+                            cmd_name,
+                        )
+                        continue
 
                     logger.debug(
                         "Received valid %s data length: %s",
@@ -681,7 +711,7 @@ class RenogyBleClient:
                             device.name,
                         )
 
-                if not any_command_succeeded:
+                if not any_command_succeeded and error is None:
                     error = RuntimeError("No commands completed successfully")
             except BleakError as exc:
                 logger.info("BLE error with device %s: %s", device.name, str(exc))
@@ -1418,7 +1448,13 @@ class RenogyBleClient:
         if session.notify_started:
             return
 
+        notification_client = session.client
+
         def notification_handler(_sender, data):
+            # Ignore a callback queued by a connection that was discarded after
+            # a timeout. Its response cannot be matched to a current request.
+            if session.client is not notification_client:
+                return
             session.notification_data.extend(data)
             session.notification_event.set()
 

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -1728,6 +1728,92 @@ def test_read_device_stops_after_read_timeout_instead_of_misreading_reply(monkey
     assert dummy_client.disconnect_calls == 1
 
 
+@pytest.mark.parametrize("transport_mode", ["per_operation", "persistent_session"])
+def test_controller_reconnects_and_continues_after_device_info_timeout(
+    monkeypatch, transport_mode
+):
+    """A controller with optional metadata must still return telemetry."""
+
+    class DummyClient:
+        def __init__(self, *, device_info_times_out: bool):
+            self.is_connected = True
+            self.device_info_times_out = device_info_times_out
+            self.disconnect_calls = 0
+            self.requested_registers: list[int] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            register = int.from_bytes(payload[2:4], "big")
+            self.requested_registers.append(register)
+            if register == 12 and self.device_info_times_out:
+                return
+
+            word_count = int.from_bytes(payload[4:6], "big")
+            values = [0] * word_count
+            if register == 26:
+                values = [DEFAULT_DEVICE_ID]
+            elif register == 57348:
+                values = [100]
+            elif register == 256:
+                values[:3] = [75, 128, 250]
+            self._notify_handler(
+                None,
+                _modbus_read_response(DEFAULT_DEVICE_ID, values),
+            )
+
+        async def stop_notify(self, *_args, **_kwargs):
+            pass
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    clients = [
+        DummyClient(device_info_times_out=True),
+        DummyClient(device_info_times_out=False),
+    ]
+    establish_calls = 0
+
+    async def _fake_establish_connection(*_args, **_kwargs):
+        nonlocal establish_calls
+        client = clients[establish_calls]
+        establish_calls += 1
+        return client
+
+    from renogy_ble import ble as ble_module
+
+    monkeypatch.setattr(ble_module, "establish_connection", _fake_establish_connection)
+
+    client = RenogyBleClient(
+        max_notification_wait_time=0.01,
+        transport_mode=transport_mode,
+    )
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="controller")
+
+    async def _run():
+        result = await client.read_device(device)
+        await client.close()
+        return result
+
+    result = asyncio.run(_run())
+
+    assert result.success is True
+    assert result.error is None
+    assert result.parsed_data["battery_voltage"] == 12.8
+    assert "model" not in result.parsed_data
+    assert establish_calls == 2
+    assert clients[0].requested_registers == [12]
+    assert clients[1].requested_registers == [26, 57348, 256]
+    assert clients[0].disconnect_calls == 1
+    assert clients[1].disconnect_calls == 1
+
+
 def test_read_timeout_reconnects_before_next_persistent_session_poll(monkeypatch):
     """A timed-out persistent session must not be reused by the next poll."""
 


### PR DESCRIPTION
## Problem

Standard controllers that do not return a valid `device_info` response at register `0x000C` stopped exposing all telemetry after renogy-ble 2.4.0. The timeout safety added in #128 correctly discarded the ambiguous Modbus stream, but it also ended the poll. Because `device_info` is first on every poll, battery and PV reads were never attempted and renogy-ha eventually marked the device unavailable.

This change disconnects the timed-out controller session, establishes a fresh connection, and continues with the remaining commands. Each command is still attempted at most once per poll, and delayed callbacks from the discarded connection are ignored. DCC, battery, and inverter timeout behavior is unchanged.

For example, a controller that times out at `device_info` now makes these requests across two connections:

```text
connection 1: 0x000C (timeout, disconnect)
connection 2: 0x001A, 0xE004, 0x0100 (telemetry succeeds)
```

The regression was reported in IAmTheMitchell/renogy-ha#221. After this is released, renogy-ha will need its dependency pin updated before users receive the fix.

## Validation

- `uv run --no-sync ruff format .`: pass, 22 files unchanged
- `uv run --no-sync ruff check . --output-format=github`: pass
- `uv run --no-sync ty check . --output-format=github`: pass
- `uv run --no-sync pytest tests`: 135 passed
- Regression coverage runs in both `per_operation` and `persistent_session` modes and verifies telemetry after the first connection times out.
- Existing tests still verify that DCC polling stops after a timeout and that a persistent session is replaced before the next poll.

`uv sync --locked` cannot currently create a fresh environment from `main`: UV reports that the checked-in lockfile needs to be updated. This PR does not change dependencies or the lockfile, so validation used the complete existing project environment.
