### PR TITLE
feat: add RIV4835CSH1S Program 28 readback

### DIFF
--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -914,6 +914,11 @@ class RenogyBleClient:
                 ),
                 _InverterReadSpec(4327, 7, "_parse_inverter_charging_response"),
                 _InverterReadSpec(4408, 6, "_parse_riv4835csh1s_load_response"),
+                _InverterReadSpec(
+                    0xE205,
+                    1,
+                    "_parse_riv4835csh1s_ac_charge_current",
+                ),
             )
 
         return (
@@ -1160,6 +1165,13 @@ class RenogyBleClient:
             "line_charging_current": values[4] * 0.1,
             "load_percentage": values[5],
         }
+
+    @staticmethod
+    def _parse_riv4835csh1s_ac_charge_current(data: bytes) -> dict[str, Any]:
+        """Parse RIV4835CSH1S Program 28 maximum AC charging current."""
+        return RenogyBleClient._parse_inverter_setpoint(
+            data, "inverter_ac_charge_current"
+        )
 
     @staticmethod
     def _parse_inverter_load_response(data: bytes) -> dict[str, Any]:

--- a/tests/test_riv4835csh1s.py
+++ b/tests/test_riv4835csh1s.py
@@ -28,6 +28,7 @@ def test_riv4835csh1s_read_profile() -> None:
         (4109, 1, "_parse_inverter_device_id_response"),
         (4327, 7, "_parse_inverter_charging_response"),
         (4408, 6, "_parse_riv4835csh1s_load_response"),
+        (0xE205, 1, "_parse_riv4835csh1s_ac_charge_current"),
     ]
     assert specs[0].retries == 2
     assert all(spec.register != 4311 for spec in specs)
@@ -106,6 +107,16 @@ def test_riv4835csh1s_load_response() -> None:
     assert parsed["load_percentage"] == 0
 
 
+@pytest.mark.parametrize(("raw", "amps"), [(0, 0.0), (50, 5.0), (100, 10.0)])
+def test_riv4835csh1s_program28_response(raw: int, amps: float) -> None:
+    """Parse hardware-validated Program 28 values from register 0xE205."""
+    parsed = RenogyBleClient._parse_riv4835csh1s_ac_charge_current(
+        _modbus_read_response([raw])
+    )
+
+    assert parsed["inverter_ac_charge_current"] == pytest.approx(amps)
+
+
 def test_riv4835csh1s_read_uses_only_supported_registers(monkeypatch) -> None:
     """Read captured RIV frames without probing unsupported registers."""
 
@@ -132,6 +143,7 @@ def test_riv4835csh1s_read_uses_only_supported_registers(monkeypatch) -> None:
                 4109: _modbus_read_response([32]),
                 4327: bytes.fromhex("20030e003cfe1102690069028a000209e7e8e0"),
                 4408: bytes.fromhex("20030c000200140016000001710000a0f6"),
+                0xE205: _modbus_read_response([100]),
             }
             self._notify_handler(None, responses[register])
 
@@ -171,9 +183,11 @@ def test_riv4835csh1s_read_uses_only_supported_registers(monkeypatch) -> None:
     assert result.parsed_data["charging_current"] == pytest.approx(-49.5)
     assert result.parsed_data["solar_voltage"] == pytest.approx(61.7)
     assert result.parsed_data["load_current"] == pytest.approx(0.2)
+    assert result.parsed_data["inverter_ac_charge_current"] == pytest.approx(10.0)
     assert [int.from_bytes(request[2:4], "big") for request in dummy_client.writes] == [
         4000,
         4109,
         4327,
         4408,
+        0xE205,
     ]


### PR DESCRIPTION
## Summary

Add model-specific readback for **RIV4835CSH1S Program 28 — Maximum AC Charging Current**.

Hardware validation identified holding register `0xE205` as Program 28 on a real RIV4835CSH1S:

- LCD `0 A` -> raw `0`
- LCD `5 A` -> raw `50`
- LCD `10 A` -> raw `100`

The register therefore uses the inverter setpoint convention of `0.1 A` per raw unit.

## Change

For the RIV4835CSH1S read profile only:

- read `0xE205` with Modbus function `0x03`
- parse it as `inverter_ac_charge_current`
- leave the generic/REGO inverter profile unchanged

This PR adds no new write mechanism. `renogy-ble` already has the validated single-register function-`0x06` write path; the companion Home Assistant change will use that existing path with `0xE205`.

## Hardware write validation

The existing write path was also validated against the same inverter before preparing this patch:

- fresh read `0xE205=50`, write raw `100` with function `0x06`, exact CRC-valid echo, readback `100`, physical LCD changed `5 A -> 10 A`
- fresh read `0xE205=100`, write raw `0`, exact CRC-valid echo, readback `0`, physical LCD changed `10 A -> 0 A`
- at `0 A`, line charging dropped to `0.0 A` while AC bypass and solar charging remained operational

## Tests

Adds coverage for:

- RIV4835 read-profile inclusion of `0xE205`
- raw `0/50/100` parsing to `0/5/10 A`
- end-to-end RIV poll including the Program 28 value
- unchanged generic inverter profile

Companion Home Assistant PR: IAmTheMitchell/renogy-ha#223