### PR TITLE
fix: back off repeated controller metadata timeouts

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -120,3 +120,14 @@ and installed with:
 ```bash
 pip install renogy-ble
 ```
+
+
+## Optional controller metadata
+
+Controller polls tolerate an unanswered `device_info` read by reconnecting before
+reading the remaining commands. After three consecutive metadata timeouts on
+polls that successfully parse PV telemetry, the library skips `device_info` for
+one hour. It then probes again; another timeout with working telemetry starts
+another one-hour cooldown. A successful metadata read or a poll without valid PV
+telemetry resets the cooldown. State belongs to the device object and is reset
+when that object is recreated. Other device families retain their existing reads.

--- a/src/renogy_ble/ble.py
+++ b/src/renogy_ble/ble.py
@@ -8,6 +8,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from time import monotonic
 from typing import Any, Literal, Optional
 
 from bleak.backends.device import BLEDevice
@@ -55,6 +56,8 @@ RIV4835CSH1S_MODEL = "RIV4835CSH1S"
 
 # Default device type
 DEFAULT_DEVICE_TYPE = "controller"
+DEVICE_INFO_TIMEOUT_THRESHOLD = 3
+DEVICE_INFO_RETRY_INTERVAL = 3600
 
 # Default transport mode for request/response devices.
 DEFAULT_TRANSPORT_MODE = "per_operation"
@@ -242,6 +245,9 @@ class RenogyBLEDevice:
 
         self.ble_device = ble_device
         self.address = ble_device.address
+        # Optional controller metadata backoff survives transport reconnects.
+        self._device_info_timeout_count = 0
+        self._device_info_retry_at = 0.0
 
         cleaned_name = clean_device_name(ble_device.name)
         # BLEDevice.name is an OS name and is not guaranteed to be the local
@@ -603,6 +609,8 @@ class RenogyBleClient:
                 )
 
             any_command_succeeded = False
+            device_info_timed_out = False
+            controller_telemetry_succeeded = False
             error: Exception | None = None
 
             try:
@@ -615,6 +623,15 @@ class RenogyBleClient:
                     command_items.sort(key=lambda item: item[1][1] != 12)
 
                 for command_index, (cmd_name, cmd) in enumerate(command_items):
+                    if (
+                        device.device_type == DEFAULT_DEVICE_TYPE
+                        and cmd_name == "device_info"
+                        and monotonic() < device._device_info_retry_at
+                    ):
+                        logger.debug(
+                            "Skipping device_info during cooldown for %s", device.name
+                        )
+                        continue
                     adjusted_cmd = self._adjust_dcc_command_for_model(
                         device, cmd_name, cmd
                     )
@@ -653,6 +670,11 @@ class RenogyBleClient:
                             device_name=device.name,
                         )
                     except asyncio.TimeoutError:
+                        if (
+                            device.device_type == DEFAULT_DEVICE_TYPE
+                            and cmd_name == "device_info"
+                        ):
+                            device_info_timed_out = True
                         # The response stream is desynchronized; a late reply to
                         # this command would be misread as the next command's.
                         if (
@@ -704,6 +726,12 @@ class RenogyBleClient:
                             device.name,
                         )
                         any_command_succeeded = True
+                        if device.device_type == DEFAULT_DEVICE_TYPE:
+                            if cmd_name == "device_info":
+                                device._device_info_timeout_count = 0
+                                device._device_info_retry_at = 0.0
+                            elif cmd_name == "pv":
+                                controller_telemetry_succeeded = True
                     else:
                         logger.info(
                             "Failed to parse %s data from device %s",
@@ -721,6 +749,23 @@ class RenogyBleClient:
                     "Error reading data from device %s: %s", device.name, str(exc)
                 )
                 error = exc
+
+            if device.device_type == DEFAULT_DEVICE_TYPE:
+                if controller_telemetry_succeeded and device_info_timed_out:
+                    device._device_info_timeout_count += 1
+                    if (
+                        device._device_info_timeout_count
+                        >= DEVICE_INFO_TIMEOUT_THRESHOLD
+                    ):
+                        # Retry hourly so temporary faults cannot disable metadata
+                        # permanently.
+                        device._device_info_retry_at = (
+                            monotonic() + DEVICE_INFO_RETRY_INTERVAL
+                        )
+                elif not controller_telemetry_succeeded:
+                    # An unhealthy poll is not evidence of unsupported metadata.
+                    device._device_info_timeout_count = 0
+                    device._device_info_retry_at = 0.0
 
             if error is not None or session.desynchronized:
                 await self._close_session(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -2377,3 +2377,120 @@ def test_non_g6_dcc_keeps_discrete_status_read(monkeypatch):
 
     assert (256, 32) in requests
     assert (288, 8) in requests
+
+
+@pytest.mark.parametrize("transport_mode", ["per_operation", "persistent_session"])
+def test_controller_metadata_cooldown_retries_and_recovers(monkeypatch, transport_mode):
+    """Only repeated metadata failures with working telemetry trigger backoff."""
+    telemetry_fails = False
+
+    class DummyClient:
+        def __init__(self, *, device_info_times_out: bool):
+            self.is_connected = True
+            self.device_info_times_out = device_info_times_out
+            self.disconnect_calls = 0
+            self.requested_registers: list[int] = []
+            self._notify_handler: Callable[[object | None, bytes], None] | None = None
+
+        async def start_notify(self, *_args, **_kwargs):
+            self._notify_handler = _args[1]
+
+        async def write_gatt_char(self, _uuid, payload):
+            if self._notify_handler is None:
+                raise AssertionError("Notify handler was not set.")
+
+            register = int.from_bytes(payload[2:4], "big")
+            self.requested_registers.append(register)
+            if (register == 12 and self.device_info_times_out) or (
+                register == 256 and telemetry_fails
+            ):
+                return
+
+            word_count = int.from_bytes(payload[4:6], "big")
+            values = [0] * word_count
+            if register == 26:
+                values = [DEFAULT_DEVICE_ID]
+            elif register == 57348:
+                values = [100]
+            elif register == 256:
+                values[:3] = [75, 128, 250]
+            self._notify_handler(
+                None,
+                _modbus_read_response(DEFAULT_DEVICE_ID, values),
+            )
+
+        async def stop_notify(self, *_args, **_kwargs):
+            pass
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+    from renogy_ble import ble as ble_module
+
+    now = 100.0
+    metadata_fails = True
+    clients = []
+
+    async def establish(*_args, **_kwargs):
+        connection = DummyClient(device_info_times_out=metadata_fails)
+        clients.append(connection)
+        return connection
+
+    monkeypatch.setattr(ble_module, "establish_connection", establish)
+    monkeypatch.setattr(ble_module, "monotonic", lambda: now)
+    client = RenogyBleClient(
+        max_notification_wait_time=0.001, transport_mode=transport_mode
+    )
+    device = RenogyBLEDevice(_mock_ble_device(), device_type="controller")
+
+    async def poll():
+        before = sum(c.requested_registers.count(12) for c in clients)
+        result = await client.read_device(device)
+        after = sum(c.requested_registers.count(12) for c in clients)
+        return result, after - before
+
+    async def run():
+        nonlocal now, metadata_fails, telemetry_fails
+        # General communication failures must not accumulate metadata backoff.
+        telemetry_fails = True
+        for _ in range(4):
+            _, attempts = await poll()
+            assert attempts == 1
+        telemetry_fails = False
+        for _ in range(3):
+            result, attempts = await poll()
+            assert result.success and result.parsed_data["battery_voltage"] == 12.8
+            assert attempts == 1
+        for _ in range(2):
+            result, attempts = await poll()
+            assert result.success and attempts == 0
+        # Retry after one hour; another failure starts another cooldown.
+        now += 3600
+        _, attempts = await poll()
+        assert attempts == 1
+        _, attempts = await poll()
+        assert attempts == 0
+        # A telemetry failure cancels the cooldown and allows another probe.
+        telemetry_fails = True
+        await poll()
+        telemetry_fails = False
+        _, attempts = await poll()
+        assert attempts == 1
+        # A valid metadata response resets the consecutive timeout count.
+        metadata_fails = False
+        for c in clients:
+            c.device_info_times_out = False
+        _, attempts = await poll()
+        assert attempts == 1
+        metadata_fails = True
+        for c in clients:
+            c.device_info_times_out = True
+        for _ in range(3):
+            _, attempts = await poll()
+            assert attempts == 1
+        _, attempts = await poll()
+        assert attempts == 0
+        await client.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
Controllers that never answer `device_info` currently pay a timeout and reconnect on every poll, even while telemetry works. After three metadata timeouts on polls with successfully parsed PV telemetry, skip that optional read for one hour, then probe again. Successful metadata or failed telemetry resets the cooldown; other device families keep their existing behavior.

Follow-up to https://github.com/IAmTheMitchell/renogy-ha/issues/221#issuecomment-5543565209. This is a library change; the HA integration will need a dependency update after a library release to consume it.

Validation: Ruff format/lint, ty, all 137 tests, and `git diff --check` passed. Regression coverage exercises both transport modes, repeated failures, cooldown expiry, metadata recovery, and telemetry failure. Independent review found no actionable issues. No physical BLE test was performed.

Validation used the existing project environment through `uv run --no-sync` with `PYTHONPATH=src`. A fresh `uv sync --locked` reported that the existing lockfile needs updating; dependency files were left unchanged.
